### PR TITLE
kubeconfig improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,5 @@ kubeconfig
 !kubeconfig/
 .sops.yaml
 dist/
-topf
 CHANGES.md
 venv/mkdocs

--- a/cmd/topf/kubeconfig.go
+++ b/cmd/topf/kubeconfig.go
@@ -6,6 +6,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/postfinance/topf/internal/cmd/kubeconfig"
 	"github.com/urfave/cli/v3"
@@ -17,10 +18,17 @@ func newKubeconfigCmd() *cli.Command {
 		Name:   "kubeconfig",
 		Usage:  "generate a temporary admin kubeconfig",
 		Before: noPositionalArgs,
-		Action: func(ctx context.Context, _ *cli.Command) error {
+		Flags: []cli.Flag{
+			&cli.DurationFlag{
+				Name:  "validity",
+				Usage: "validity duration of the client certificate",
+				Value: 12 * time.Hour,
+			},
+		},
+		Action: func(ctx context.Context, cmd *cli.Command) error {
 			t := MustGetRuntime(ctx)
 
-			kubeconfigStruct, err := kubeconfig.Generate(t)
+			kubeconfigStruct, err := kubeconfig.Generate(t, cmd.Duration("validity"))
 			if err != nil {
 				return fmt.Errorf("couldn't generate kubeconfig: %w", err)
 			}

--- a/cmd/topf/nodes.go
+++ b/cmd/topf/nodes.go
@@ -106,9 +106,9 @@ func renderNodesTable(nodes []*topf.Node) error {
 		}
 
 		if len(node.MachineStatus.Status.UnmetConditions) > 0 {
-			var conditions []string
-			for _, cond := range node.MachineStatus.Status.UnmetConditions {
-				conditions = append(conditions, cond.Name+": "+cond.Reason)
+			conditions := make([]string, len(node.MachineStatus.Status.UnmetConditions))
+			for i, cond := range node.MachineStatus.Status.UnmetConditions {
+				conditions[i] = cond.Name + ": " + cond.Reason
 			}
 
 			unmetConditions = strings.Join(conditions, "\n")

--- a/docs/commands/kubeconfig.md
+++ b/docs/commands/kubeconfig.md
@@ -6,7 +6,7 @@ The `kubeconfig` command generates a temporary admin kubeconfig for cluster acce
 
 The generated kubeconfig:
 
-- Is valid for **12 hours**
+- Is valid for **12 hours** (configurable via `--validity`)
 - Uses a client certificate with `system:masters` group (full admin access)
 - Is signed by the cluster's Kubernetes CA
 - Context name: `topf@<cluster-name>`

--- a/internal/cmd/kubeconfig/kubeconfig.go
+++ b/internal/cmd/kubeconfig/kubeconfig.go
@@ -36,11 +36,13 @@ func Generate(t topf.Topf) (*api.Config, error) {
 
 	clusterName := t.Config().ClusterName
 
+	contextName := "topf@" + clusterName
+
 	// Generate kubeconfig
 	kubeconfig := &api.Config{
 		APIVersion:     "v1",
 		Kind:           "Config",
-		CurrentContext: "topf@" + clusterName,
+		CurrentContext: contextName,
 		Clusters: map[string]*api.Cluster{
 			clusterName: {
 				Server:                   t.Config().ClusterEndpoint.String(),
@@ -48,13 +50,13 @@ func Generate(t topf.Topf) (*api.Config, error) {
 			},
 		},
 		Contexts: map[string]*api.Context{
-			"topf@" + clusterName: {
+			contextName: {
 				Cluster:  clusterName,
-				AuthInfo: "topf",
+				AuthInfo: contextName,
 			},
 		},
 		AuthInfos: map[string]*api.AuthInfo{
-			"topf": {
+			contextName: {
 				ClientCertificateData: clientCert,
 				ClientKeyData:         clientKey,
 			},


### PR DESCRIPTION
* Makes the kubeconfig certificate duration configurable. User might want to keep that one short in a CI/CD pipeline.
* Renames the user from `topf` to `topf@<context` in kubeconfig such that it's easier to merge with other Topf kubeconfigs
* Small lintfix and .gitignore fix.