### PR TITLE
feat: add --wait-for-maintenance flag to reset

### DIFF
--- a/cmd/topf/reset.go
+++ b/cmd/topf/reset.go
@@ -31,6 +31,11 @@ func newResetCmd() *cli.Command {
 				Value: false,
 				Usage: "if true, shut down machine after reset. otherwise, machine reboots.",
 			},
+			&cli.BoolFlag{
+				Name:  "wait-for-maintenance",
+				Value: false,
+				Usage: "wait for all reset nodes to reach maintenance mode",
+			},
 		},
 		Description: `This command resets a Talos node to its initial state, wiping the state and ephemeral system partitions and rebooting the node.`,
 		Before:      noPositionalArgs,
@@ -38,10 +43,11 @@ func newResetCmd() *cli.Command {
 			t := MustGetRuntime(ctx)
 
 			opts := reset.Options{
-				Confirm:  c.Bool("confirm"),
-				Full:     c.Bool("full"),
-				Graceful: c.Bool("graceful"),
-				Shutdown: c.Bool("shutdown"),
+				Confirm:            c.Bool("confirm"),
+				Full:               c.Bool("full"),
+				Graceful:           c.Bool("graceful"),
+				Shutdown:           c.Bool("shutdown"),
+				WaitForMaintenance: c.Bool("wait-for-maintenance"),
 			}
 
 			return reset.Execute(ctx, t, opts)

--- a/internal/cmd/reset/reset.go
+++ b/internal/cmd/reset/reset.go
@@ -6,6 +6,7 @@ package reset
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -122,6 +123,8 @@ func Execute(ctx context.Context, t topf.Topf, opts Options) error {
 
 		var wg sync.WaitGroup
 
+		errs := make(chan error, len(resetNodes))
+
 		for _, n := range resetNodes {
 			wg.Add(1)
 
@@ -132,6 +135,9 @@ func Execute(ctx context.Context, t topf.Topf, opts Options) error {
 
 				if err := n.WaitForMaintenance(ctx, logger); err != nil {
 					logger.Error("failed waiting for maintenance mode", "error", err)
+
+					errs <- err
+
 					return
 				}
 
@@ -140,6 +146,16 @@ func Execute(ctx context.Context, t topf.Topf, opts Options) error {
 		}
 
 		wg.Wait()
+		close(errs)
+
+		var waitErrs []error
+		for err := range errs {
+			waitErrs = append(waitErrs, err)
+		}
+
+		if err := errors.Join(waitErrs...); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/internal/cmd/reset/reset.go
+++ b/internal/cmd/reset/reset.go
@@ -7,6 +7,7 @@ package reset
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"github.com/postfinance/topf/internal/interactive"
 	"github.com/postfinance/topf/internal/topf"
@@ -20,9 +21,10 @@ type Options struct {
 	Confirm bool
 	// Whether to perform a full wipe of the installation disk. If false, only
 	// STATE and EPHEMERAL partitions are wiped.
-	Full     bool
-	Graceful bool
-	Shutdown bool
+	Full               bool
+	Graceful           bool
+	Shutdown           bool
+	WaitForMaintenance bool
 }
 
 // Result contains the result of the reset operation
@@ -47,6 +49,8 @@ func Execute(ctx context.Context, t topf.Topf, opts Options) error {
 		logger.Info("no node to act upon")
 		return nil
 	}
+
+	var resetNodes []*topf.Node
 
 	for _, n := range nodes {
 		logger := logger.With(n.Attrs())
@@ -107,9 +111,36 @@ func Execute(ctx context.Context, t topf.Topf, opts Options) error {
 		logger.Info("reset initiated")
 
 		result.SuccessCount++
+
+		resetNodes = append(resetNodes, n)
 	}
 
 	logger.Info("reset completed", "result", *result)
+
+	if opts.WaitForMaintenance && len(resetNodes) > 0 {
+		logger.Info("waiting for nodes to reach maintenance mode", "count", len(resetNodes))
+
+		var wg sync.WaitGroup
+
+		for _, n := range resetNodes {
+			wg.Add(1)
+
+			go func(n *topf.Node) {
+				defer wg.Done()
+
+				logger := logger.With(n.Attrs())
+
+				if err := n.WaitForMaintenance(ctx, logger); err != nil {
+					logger.Error("failed waiting for maintenance mode", "error", err)
+					return
+				}
+
+				logger.Info("node is in maintenance mode")
+			}(n)
+		}
+
+		wg.Wait()
+	}
 
 	return nil
 }

--- a/internal/topf/wait.go
+++ b/internal/topf/wait.go
@@ -93,3 +93,27 @@ func (n *Node) Stabilize(ctx context.Context, logger *slog.Logger, stabilization
 
 	return retry.Constant(time.Minute*15, retry.WithErrorLogging(logger.Enabled(ctx, slog.LevelDebug))).RetryWithContext(ctx, waitForMachineReady)
 }
+
+// WaitForMaintenance waits for the talos machine to reach maintenance mode
+func (n *Node) WaitForMaintenance(ctx context.Context, logger *slog.Logger) error {
+	return retry.Constant(time.Minute*15,
+		retry.WithErrorLogging(logger.Enabled(ctx, slog.LevelDebug)),
+	).RetryWithContext(ctx, func(ctx context.Context) error {
+		nodeClient, err := n.Client(ctx)
+		if err != nil {
+			return retry.ExpectedErrorf("couldn't get client: %w", err)
+		}
+		defer nodeClient.Close()
+
+		machineStatus, err := safe.ReaderGetByID[*runtime.MachineStatus](ctx, nodeClient.COSI, runtime.MachineStatusID)
+		if err != nil {
+			return retry.ExpectedErrorf("couldn't get machine status: %s", err)
+		}
+
+		if machineStatus.TypedSpec().Stage != runtime.MachineStageMaintenance {
+			return retry.ExpectedErrorf("machine not in maintenance mode: %s", machineStatus.TypedSpec().Stage)
+		}
+
+		return nil
+	})
+}


### PR DESCRIPTION
This is useful in automated pipelines, where you want to chain a reset with an apply for a complete re-install.