### PR TITLE
feat: add factory/platform config surface

### DIFF
--- a/docs/commands/upgrade.md
+++ b/docs/commands/upgrade.md
@@ -33,7 +33,7 @@ talosVersion: 1.12.7
 schematicId: 376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba
 ```
 
-This generates `factory.talos.dev/installer/<schematicId>:v<talosVersion>` as the base installer image. Since this patch is applied first, any subsequent `machine.install.image` patch (shared or node-level) will override it.
+This generates `factory.talos.dev/metal-installer/<schematicId>:v<talosVersion>` as the base installer image. Since this patch is applied first, any subsequent `machine.install.image` patch (shared or node-level) will override it. The factory and platform can be customized via `factory` and `platform` in `topf.yaml` (or per node).
 
 ### Manual installer image patch
 
@@ -44,7 +44,7 @@ Alternatively, manage the installer image explicitly via a patch. The target ima
 ```yaml
 machine:
   install:
-    image: factory.talos.dev/installer/376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba:v1.12.0
+    image: factory.talos.dev/metal-installer/376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba:v1.12.0
 ```
 
 ### Per-node override
@@ -56,7 +56,7 @@ To upgrade a single node to a different version or schematic, add a node-specifi
 ```yaml
 machine:
   install:
-    image: factory.talos.dev/installer/376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba:v1.13.0
+    image: factory.talos.dev/metal-installer/376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba:v1.13.0
 ```
 
 Because node-level patches are merged last (see [Configuration Model](../configuration-model.md)), this override applies only to that host.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,6 +14,10 @@ kubernetesVersion: 1.34.1
 talosVersion: 1.12.7
 schematicId: 376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba
 
+# Optional: Custom image factory and platform (defaults: factory.talos.dev, metal)
+# factory: factory.talos.dev
+# platform: metal
+
 # Optional: Directory containing patches (default: ".")
 configDir: .
 
@@ -36,6 +40,10 @@ nodes:
   - host: node2
     ip: 172.20.10.3
     role: worker
+  - host: cloud-node1
+    ip: 10.0.1.5
+    role: worker
+    platform: aws  # per-node platform override
 ```
 
 ## Configuration Fields
@@ -47,6 +55,8 @@ nodes:
 | `kubernetesVersion` | Yes      | -       | Kubernetes version to install                                                            |
 | `talosVersion`      | No       | bundled Talos version | Talos version used to generate the installer image and as fallback for [`render`](commands/render.md) when not using `--online` |
 | `schematicId`       | No       | default (no extensions) | Talos image factory schematic ID used in the auto-generated `machine.install.image` patch |
+| `factory`           | No       | `factory.talos.dev` | Talos image factory address. Can be overridden per node |
+| `platform`          | No       | `metal` | Talos platform identifier (e.g. `metal`, `aws`, `gcp`). Can be overridden per node |
 | `configDir`         | No       | `.`     | Directory containing patch files and node-specific configs                               |
 | `secretsProvider`   | No       | -       | Path to binary that manages secrets.yaml                                                 |
 | `nodesProvider`     | No       | -       | Path to binary that provides additional nodes                                            |
@@ -57,12 +67,14 @@ nodes:
 
 Each entry in the `nodes` list has the following fields:
 
-| Field  | Required | Description                                                                                                     |
-| ------ | -------- | --------------------------------------------------------------------------------------------------------------- |
-| `host` | Yes      | Name of the node. Can be a FQDN or short name. Used for display, logging, and certificate validation            |
-| `ip`   | No       | IP address used to connect to the node directly instead of resolving `host` via DNS                             |
-| `role` | Yes      | Role of the node: `control-plane` or `worker`                                                                   |
-| `data` | No       | Arbitrary key-value data for use in [patch templates](configuration-model.md#templating) via `.Node.Data.<key>` |
+| Field      | Required | Description                                                                                                     |
+| ---------- | -------- | --------------------------------------------------------------------------------------------------------------- |
+| `host`     | Yes      | Name of the node. Can be a FQDN or short name. Used for display, logging, and certificate validation            |
+| `ip`       | No       | IP address used to connect to the node directly instead of resolving `host` via DNS                             |
+| `role`     | Yes      | Role of the node: `control-plane` or `worker`                                                                   |
+| `factory`  | No       | Overrides the cluster-level `factory` for this node                                                             |
+| `platform` | No       | Overrides the cluster-level `platform` for this node                                                            |
+| `data`     | No       | Arbitrary key-value data for use in [patch templates](configuration-model.md#templating) via `.Node.Data.<key>` |
 
 ## Global Flags
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -53,8 +53,8 @@ nodes:
 | `clusterName`       | Yes      | -       | Name of the Kubernetes cluster                                                           |
 | `clusterEndpoint`   | Yes      | -       | Kubernetes API endpoint URL                                                              |
 | `kubernetesVersion` | Yes      | -       | Kubernetes version to install                                                            |
-| `talosVersion`      | No       | bundled Talos version | Talos version used to generate the installer image and as fallback for [`render`](commands/render.md) when not using `--online` |
-| `schematicId`       | No       | default (no extensions) | Talos image factory schematic ID used in the auto-generated `machine.install.image` patch |
+| `talosVersion`      | No       | bundled Talos version | Talos version used to generate the installer image. Can be overridden per node |
+| `schematicId`       | No       | default (no extensions) | Talos image factory schematic ID used in the auto-generated `machine.install.image` patch. Can be overridden per node |
 | `factory`           | No       | `factory.talos.dev` | Talos image factory address. Can be overridden per node |
 | `platform`          | No       | `metal` | Talos platform identifier (e.g. `metal`, `aws`, `gcp`). Can be overridden per node |
 | `configDir`         | No       | `.`     | Directory containing patch files and node-specific configs                               |
@@ -67,14 +67,16 @@ nodes:
 
 Each entry in the `nodes` list has the following fields:
 
-| Field      | Required | Description                                                                                                     |
-| ---------- | -------- | --------------------------------------------------------------------------------------------------------------- |
-| `host`     | Yes      | Name of the node. Can be a FQDN or short name. Used for display, logging, and certificate validation            |
-| `ip`       | No       | IP address used to connect to the node directly instead of resolving `host` via DNS                             |
-| `role`     | Yes      | Role of the node: `control-plane` or `worker`                                                                   |
-| `factory`  | No       | Overrides the cluster-level `factory` for this node                                                             |
-| `platform` | No       | Overrides the cluster-level `platform` for this node                                                            |
-| `data`     | No       | Arbitrary key-value data for use in [patch templates](configuration-model.md#templating) via `.Node.Data.<key>` |
+| Field          | Required | Description                                                                                                     |
+| -------------- | -------- | --------------------------------------------------------------------------------------------------------------- |
+| `host`         | Yes      | Name of the node. Can be a FQDN or short name. Used for display, logging, and certificate validation            |
+| `ip`           | No       | IP address used to connect to the node directly instead of resolving `host` via DNS                             |
+| `role`         | Yes      | Role of the node: `control-plane` or `worker`                                                                   |
+| `talosVersion` | No       | Overrides the cluster-level `talosVersion` for this node                                                         |
+| `schematicId`  | No       | Overrides the cluster-level `schematicId` for this node                                                         |
+| `factory`      | No       | Overrides the cluster-level `factory` for this node                                                             |
+| `platform`     | No       | Overrides the cluster-level `platform` for this node                                                             |
+| `data`         | No       | Arbitrary key-value data for use in [patch templates](configuration-model.md#templating) via `.Node.Data.<key>` |
 
 ## Global Flags
 

--- a/internal/topf/node.go
+++ b/internal/topf/node.go
@@ -59,13 +59,13 @@ func (n *Node) RunningSchematic() string {
 }
 
 // InstallerImage returns the fully resolved installer image for this node.
-// Resolution order for factory and platform: node -> cluster config -> default.
+// All four components (factory, platform, schematic, talosVersion) resolve per node -> cluster config -> default.
 func (n *Node) InstallerImage() string {
 	cfg := n.t.Config()
 	factory := cmp.Or(n.Node.Factory, cfg.Factory, DefaultFactory)
 	platform := cmp.Or(n.Node.Platform, cfg.Platform, DefaultPlatform)
-	schematic := cmp.Or(cfg.SchematicID, DefaultSchematic)
-	talosVersion := strings.TrimPrefix(cmp.Or(cfg.TalosVersion, version.Tag), "v")
+	schematic := cmp.Or(n.Node.SchematicID, cfg.SchematicID, DefaultSchematic)
+	talosVersion := strings.TrimPrefix(cmp.Or(n.Node.TalosVersion, cfg.TalosVersion, version.Tag), "v")
 
 	return fmt.Sprintf("%s/%s-installer/%s:v%s", factory, platform, schematic, talosVersion)
 }

--- a/internal/topf/node.go
+++ b/internal/topf/node.go
@@ -5,6 +5,7 @@ package topf
 
 import (
 	"cmp"
+	"fmt"
 	"log/slog"
 	"strings"
 
@@ -16,10 +17,14 @@ import (
 )
 
 const (
-	// DefaultSchematic is the schematic version used by Talos when no
-	// extensions or command line flags are defined
-	// TODO (v1.13): replace with images.DefaultInstallerImageSchematic
+	// DefaultSchematic is the schematic used by Talos when no extensions are configured
+	// TODO (v1.14): replace with images.DefaultInstallerImageSchematic
 	DefaultSchematic = "376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba"
+	// DefaultFactory is the default Talos image factory address
+	// TODO (v1.14): replace with gendata.ImageFactory
+	DefaultFactory = "factory.talos.dev"
+	// DefaultPlatform is the default Talos platform identifier
+	DefaultPlatform = "metal"
 )
 
 // Node contains runtime state information about a Talos node
@@ -51,6 +56,18 @@ func (n *Node) RunningVersion() string {
 // Empty if collectNodeInfo has not been called.
 func (n *Node) RunningSchematic() string {
 	return n.runningSchematic
+}
+
+// InstallerImage returns the fully resolved installer image for this node.
+// Resolution order for factory and platform: node -> cluster config -> default.
+func (n *Node) InstallerImage() string {
+	cfg := n.t.Config()
+	factory := cmp.Or(n.Node.Factory, cfg.Factory, DefaultFactory)
+	platform := cmp.Or(n.Node.Platform, cfg.Platform, DefaultPlatform)
+	schematic := cmp.Or(cfg.SchematicID, DefaultSchematic)
+	talosVersion := strings.TrimPrefix(cmp.Or(cfg.TalosVersion, version.Tag), "v")
+
+	return fmt.Sprintf("%s/%s-installer/%s:v%s", factory, platform, schematic, talosVersion)
 }
 
 // MarshalYAML implements custom YAML marshalling to properly serialize the Error field

--- a/internal/topf/nodes.go
+++ b/internal/topf/nodes.go
@@ -98,7 +98,7 @@ func (t *topf) generateNodeConfig(node *Node) error {
 		return fmt.Errorf("couldn't load patches: %w", err)
 	}
 
-	installPatch, err := installerImagePatch(t.Config().InstallerImage())
+	installPatch, err := installerImagePatch(node.InstallerImage())
 	if err != nil {
 		return fmt.Errorf("failed to build installer image patch: %w", err)
 	}

--- a/pkg/config/node.go
+++ b/pkg/config/node.go
@@ -18,6 +18,11 @@ type Node struct {
 	IP   *netip.Addr    `yaml:"ip,omitempty"`
 	Role NodeRole       `yaml:"role"`
 	Data map[string]any `yaml:"data,omitempty"`
+
+	// Factory overrides the cluster-level image factory address for this node
+	Factory string `yaml:"factory,omitempty"`
+	// Platform overrides the cluster-level platform identifier for this node
+	Platform string `yaml:"platform,omitempty"`
 }
 
 // Endpoint returns the IP address if set, otherwise returns the Host.

--- a/pkg/config/node.go
+++ b/pkg/config/node.go
@@ -19,6 +19,10 @@ type Node struct {
 	Role NodeRole       `yaml:"role"`
 	Data map[string]any `yaml:"data,omitempty"`
 
+	// TalosVersion overrides the cluster-level Talos version for this node
+	TalosVersion string `yaml:"talosVersion,omitempty"`
+	// SchematicID overrides the cluster-level schematic ID for this node
+	SchematicID string `yaml:"schematicId,omitempty"`
 	// Factory overrides the cluster-level image factory address for this node
 	Factory string `yaml:"factory,omitempty"`
 	// Platform overrides the cluster-level platform identifier for this node

--- a/pkg/config/topf_config.go
+++ b/pkg/config/topf_config.go
@@ -5,7 +5,6 @@
 package config
 
 import (
-	"cmp"
 	"fmt"
 	"regexp"
 	"slices"
@@ -13,15 +12,7 @@ import (
 
 	"github.com/postfinance/topf/internal/sops"
 	"github.com/postfinance/topf/pkg/providers"
-	"github.com/siderolabs/talos/pkg/machinery/version"
 	"go.yaml.in/yaml/v4"
-)
-
-const (
-	// TODO (v1.13): replace with images.DefaultInstallerImageSchematic
-	defaultSchematicID = "376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba"
-	// TODO (v1.13): replace with gendata.ImageFactory
-	imageFactory = "factory.talos.dev"
 )
 
 // TopfConfig is the main configuration structure for a Topf cluster
@@ -31,6 +22,11 @@ type TopfConfig struct {
 	KubernetesVersion string   `yaml:"kubernetesVersion"`
 	TalosVersion      string   `yaml:"talosVersion,omitempty"`
 	SchematicID       string   `yaml:"schematicId,omitempty"`
+
+	// Factory is the Talos image factory address (default: factory.talos.dev)
+	Factory string `yaml:"factory,omitempty"`
+	// Platform is the Talos platform identifier (default: metal)
+	Platform string `yaml:"platform,omitempty"`
 
 	// SecretsProvider can be optionally set to the path of a binary which is
 	// responsible for storing and retrieving secrets.yaml for a cluster. If not
@@ -118,15 +114,6 @@ func LoadFromFile(path string, nodesRegexFilter string) (config *TopfConfig, sec
 	})
 
 	return config, secrets, err
-}
-
-// InstallerImage returns the Talos installer image for the configured schematic and version,
-// defaulting to the default schematic and the bundled Talos version when not set.
-func (t *TopfConfig) InstallerImage() string {
-	schematic := cmp.Or(t.SchematicID, defaultSchematicID)
-	talosVersion := strings.TrimPrefix(cmp.Or(t.TalosVersion, version.Tag), "v")
-
-	return fmt.Sprintf("%s/installer/%s:v%s", imageFactory, schematic, talosVersion)
 }
 
 // GetSecretsProvider returns the configured secrets provider, or the default filesystem provider


### PR DESCRIPTION
permits specifying a cluster-wide factory / platform in topf.yaml, with per-node overrides for every node.
also consolidates const usages

closes #55 