### PR TITLE
feat(secrets): store secrets.yaml in configDir if specified

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -59,7 +59,7 @@ nodes:
 | `factory`           | No       | `factory.talos.dev` | Talos image factory address. Can be overridden per node |
 | `platform`          | No       | `metal` | Talos platform identifier (e.g. `metal`, `aws`, `gcp`). Can be overridden per node |
 | `secureboot`        | No       | `false` | Use the secure boot installer variant (`<platform>-installer-secureboot`). Can be overridden per node |
-| `configDir`         | No       | `.`     | Directory containing patch files and node-specific configs                               |
+| `configDir`         | No       | `.`     | Directory containing secrets.yaml, patch files and node-specific configs                 |
 | `secretsProvider`   | No       | -       | Path to binary that manages secrets.yaml                                                 |
 | `nodesProvider`     | No       | -       | Path to binary that provides additional nodes                                            |
 | `data`              | No       | -       | Arbitrary key-value data for use in [patch templates](configuration-model.md#templating) |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -19,8 +19,12 @@ schematicId: 376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba
 # platform: metal
 # secureboot: false
 
-# Optional: Directory containing patches (default: ".")
-configDir: .
+# Optional: Directory containing patches (default: same directory as topf.yaml)
+# patchesDir: .
+
+# Optional: Path to secrets.yaml (default: <dir of topf.yaml>/secrets.yaml)
+# Relative paths are resolved against the directory containing topf.yaml.
+# secretsPath: secrets.yaml
 
 # Optional: Provider binaries for dynamic configuration
 secretsProvider: /path/to/secrets-provider
@@ -59,7 +63,8 @@ nodes:
 | `factory`           | No       | `factory.talos.dev` | Talos image factory address. Can be overridden per node |
 | `platform`          | No       | `metal` | Talos platform identifier (e.g. `metal`, `aws`, `gcp`). Can be overridden per node |
 | `secureboot`        | No       | `false` | Use the secure boot installer variant (`<platform>-installer-secureboot`). Can be overridden per node |
-| `configDir`         | No       | `.`     | Directory containing secrets.yaml, patch files and node-specific configs                 |
+| `patchesDir`        | No       | directory of topf.yaml | Directory containing patch files and node-specific configurations. Relative paths are resolved against the directory containing topf.yaml |
+| `secretsPath`       | No       | `<dir of topf.yaml>/secrets.yaml` | Path to secrets.yaml. Relative paths are resolved against the directory containing topf.yaml |
 | `secretsProvider`   | No       | -       | Path to binary that manages secrets.yaml                                                 |
 | `nodesProvider`     | No       | -       | Path to binary that provides additional nodes                                            |
 | `data`              | No       | -       | Arbitrary key-value data for use in [patch templates](configuration-model.md#templating) |

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -56,7 +56,7 @@ The secrets provider manages the Talos secrets bundle (`secrets.yaml`) which con
 
 ### Default Behavior (no provider)
 
-Without a `secretsProvider`, TOPF reads from and writes to a local `secrets.yaml` file. It automatically attempts SOPS decryption on read and SOPS encryption on write. If SOPS is not available, it falls back to plaintext.
+Without a `secretsProvider`, TOPF reads from and writes to a local `secrets.yaml` file (stored in `configDir`). It automatically attempts SOPS decryption on read and SOPS encryption on write. If SOPS is not available, it falls back to plaintext.
 
 ### Binary Contract
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -56,7 +56,7 @@ The secrets provider manages the Talos secrets bundle (`secrets.yaml`) which con
 
 ### Default Behavior (no provider)
 
-Without a `secretsProvider`, TOPF reads from and writes to a local `secrets.yaml` file (stored in `configDir`). It automatically attempts SOPS decryption on read and SOPS encryption on write. If SOPS is not available, it falls back to plaintext.
+Without a `secretsProvider`, TOPF reads from and writes to a local `secrets.yaml` file. The location defaults to `secrets.yaml` next to the config file and can be overridden with `secretsPath`. It automatically attempts SOPS decryption on read and SOPS encryption on write. If SOPS is not available, it falls back to plaintext.
 
 ### Binary Contract
 

--- a/internal/topf/nodes.go
+++ b/internal/topf/nodes.go
@@ -113,7 +113,7 @@ func (t *topf) generateNodeConfig(node *Node) error {
 		SchematicID:       t.Config().SchematicID,
 		Node:              node.Node,
 		Data:              t.Config().Data,
-		ConfigDir:         t.configDir,
+		PatchesDir:        t.patchesDir,
 	}
 
 	patches, patchSecrets, err := patchContext.Load()

--- a/internal/topf/topf.go
+++ b/internal/topf/topf.go
@@ -75,15 +75,15 @@ func NewTopfRuntime(cfg RuntimeConfig) (Topf, error) {
 		return nil, err
 	}
 
-	// Validate configDir exists and is a directory
-	if stat, err := os.Stat(topfConfig.ConfigDir); err != nil {
+	// Validate patchesDir exists and is a directory
+	if stat, err := os.Stat(topfConfig.PatchesDir); err != nil {
 		if os.IsNotExist(err) {
-			return nil, fmt.Errorf("config directory does not exist: %s", topfConfig.ConfigDir)
+			return nil, fmt.Errorf("patches directory does not exist: %s", topfConfig.PatchesDir)
 		}
 
-		return nil, fmt.Errorf("failed to access config directory: %w", err)
+		return nil, fmt.Errorf("failed to access patches directory: %w", err)
 	} else if !stat.IsDir() {
-		return nil, fmt.Errorf("config path is not a directory: %s", topfConfig.ConfigDir)
+		return nil, fmt.Errorf("patches path is not a directory: %s", topfConfig.PatchesDir)
 	}
 
 	// Parse log level
@@ -106,7 +106,7 @@ func NewTopfRuntime(cfg RuntimeConfig) (Topf, error) {
 
 	return &topf{
 		TopfConfig:   topfConfig,
-		configDir:    topfConfig.ConfigDir,
+		patchesDir:   topfConfig.PatchesDir,
 		logger:       logger,
 		maskedWriter: mw,
 		confirm:      cfg.Confirm,
@@ -117,7 +117,7 @@ type topf struct {
 	*config.TopfConfig
 	mu sync.Mutex
 
-	configDir     string
+	patchesDir    string
 	secretsBundle *secrets.Bundle
 	logger        *slog.Logger
 	maskedWriter  *maskedwriter.Writer

--- a/pkg/config/patches.go
+++ b/pkg/config/patches.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"log/slog"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -30,26 +29,20 @@ type PatchContext struct {
 	SchematicID       string
 	Data              map[string]any
 	Node              *Node
-	ConfigDir         string
+	PatchesDir        string
 }
 
 // Load loads all patches applicable for the node This includes general patches,
 // role (worker/control-plane) specific patches and node specific patches in
 // that order. It also returns any secrets discovered from SOPS-encrypted patch files.
 func (p *PatchContext) Load() (patches []configpatcher.Patch, secrets []string, err error) {
-	// warn about legacy patches/ directory
-	oldDir := filepath.Join(p.ConfigDir, "patches")
-	if info, statErr := os.Stat(oldDir); statErr == nil && info.IsDir() {
-		slog.Warn("legacy patches/ directory found, rename it to all/", "path", oldDir)
-	}
-
-	patches, secrets, err = p.loadFolder(filepath.Join(p.ConfigDir, "all"))
+	patches, secrets, err = p.loadFolder(filepath.Join(p.PatchesDir, "all"))
 	if err != nil {
 		return nil, nil, err
 	}
 
 	// patches relating to role of node, control-plane or worker
-	rolePatches, roleSecrets, err := p.loadFolder(filepath.Join(p.ConfigDir, string(p.Node.Role)))
+	rolePatches, roleSecrets, err := p.loadFolder(filepath.Join(p.PatchesDir, string(p.Node.Role)))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -58,7 +51,7 @@ func (p *PatchContext) Load() (patches []configpatcher.Patch, secrets []string, 
 	secrets = append(secrets, roleSecrets...)
 
 	// patches relating to single specific node
-	nodePatches, nodeSecrets, err := p.loadFolder(filepath.Join(p.ConfigDir, "node", p.Node.Host))
+	nodePatches, nodeSecrets, err := p.loadFolder(filepath.Join(p.PatchesDir, "node", p.Node.Host))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/config/topf_config.go
+++ b/pkg/config/topf_config.go
@@ -124,5 +124,5 @@ func (t *TopfConfig) GetSecretsProvider() providers.SecretsProvider {
 		return providers.NewBinarySecretsProvider(t.SecretsProvider)
 	}
 
-	return providers.NewFilesystemSecretsProvider()
+	return providers.NewFilesystemSecretsProvider(t.ConfigDir)
 }

--- a/pkg/config/topf_config.go
+++ b/pkg/config/topf_config.go
@@ -6,6 +6,7 @@ package config
 
 import (
 	"fmt"
+	"path/filepath"
 	"regexp"
 	"slices"
 	"strings"
@@ -32,15 +33,23 @@ type TopfConfig struct {
 
 	// SecretsProvider can be optionally set to the path of a binary which is
 	// responsible for storing and retrieving secrets.yaml for a cluster. If not
-	// set, will use a local secrest.yaml with optinoal SOPS encryption.
+	// set, will use a local secrets.yaml (see SecretsPath) with optional SOPS encryption.
 	SecretsProvider string `yaml:"secretsProvider,omitempty"`
 
-	// NodesProvider can be optionally set the path of a binary which will provide additional noddes
+	// NodesProvider can be optionally set to the path of a binary which will provide additional nodes
 	NodesProvider string `yaml:"nodesProvider,omitempty"`
 
-	// ConfigDir is the directory containing patches and node-specific configurations
-	// Defaults to "." (current directory) if not specified
+	// PatchesDir is the directory containing patches and node-specific configurations.
+	// Defaults to the directory containing the config file.
+	PatchesDir string `yaml:"patchesDir,omitempty"`
+
+	// ConfigDir is deprecated: use PatchesDir instead.
 	ConfigDir string `yaml:"configDir,omitempty"`
+
+	// SecretsPath is the path to the secrets.yaml file.
+	// Relative paths are resolved against the directory containing the config file.
+	// Defaults to "secrets.yaml" next to the config file.
+	SecretsPath string `yaml:"secretsPath,omitempty"`
 
 	Nodes []Node `yaml:"nodes"`
 
@@ -48,7 +57,10 @@ type TopfConfig struct {
 	Data map[string]any `yaml:"data"`
 }
 
-// LoadFromFile loads the TopfConfig from a YAML file
+// LoadFromFile loads the TopfConfig from a YAML file.
+// PatchesDir defaults to the directory containing the config file.
+// SecretsPath defaults to "secrets.yaml" next to the config file (not inside PatchesDir).
+// Relative paths for both are resolved against the directory containing the config file.
 func LoadFromFile(path string, nodesRegexFilter string) (config *TopfConfig, secrets []string, err error) {
 	// Read file with automatic SOPS decryption if needed
 	var content []byte
@@ -69,9 +81,30 @@ func LoadFromFile(path string, nodesRegexFilter string) (config *TopfConfig, sec
 		return nil, nil, fmt.Errorf("failed to decode config: %w", err)
 	}
 
-	// Set default configDir if not specified
-	if config.ConfigDir == "" {
-		config.ConfigDir = "."
+	if config.ConfigDir != "" {
+		return nil, nil, fmt.Errorf("deprecated field 'configDir' found in %s: use 'patchesDir' instead", path)
+	}
+
+	// Resolve config file directory as absolute path
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to resolve config path: %w", err)
+	}
+
+	configFileDir := filepath.Dir(absPath)
+
+	// Set default patchesDir if not specified
+	if config.PatchesDir == "" {
+		config.PatchesDir = configFileDir
+	} else if !filepath.IsAbs(config.PatchesDir) {
+		config.PatchesDir = filepath.Join(configFileDir, config.PatchesDir)
+	}
+
+	// Set default secretsPath if not specified (next to topf.yaml, not inside patchesDir)
+	if config.SecretsPath == "" {
+		config.SecretsPath = filepath.Join(configFileDir, "secrets.yaml")
+	} else if !filepath.IsAbs(config.SecretsPath) {
+		config.SecretsPath = filepath.Join(configFileDir, config.SecretsPath)
 	}
 
 	nodesFilter := regexp.MustCompile(".*")
@@ -124,5 +157,5 @@ func (t *TopfConfig) GetSecretsProvider() providers.SecretsProvider {
 		return providers.NewBinarySecretsProvider(t.SecretsProvider)
 	}
 
-	return providers.NewFilesystemSecretsProvider(t.ConfigDir)
+	return providers.NewFilesystemSecretsProvider(t.SecretsPath)
 }

--- a/pkg/config/topf_config_test.go
+++ b/pkg/config/topf_config_test.go
@@ -1,0 +1,117 @@
+// Copyright 2026 PostFinance AG
+// SPDX-License-Identifier: MIT
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeTestConfig(t *testing.T, dir, content string) string {
+	t.Helper()
+
+	path := filepath.Join(dir, "topf.yaml")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	return path
+}
+
+func TestLoadFromFile(t *testing.T) {
+	t.Run("pathResolution", func(t *testing.T) {
+		tests := []struct {
+			name           string
+			extraYAML      []string
+			mkdir          string
+			wantPatchesDir func(absDir string) string
+			wantSecrets    func(absDir string) string
+		}{
+			{
+				name:           "defaults",
+				wantPatchesDir: func(d string) string { return d },
+				wantSecrets:    func(d string) string { return filepath.Join(d, "secrets.yaml") },
+			},
+			{
+				name:           "relativePatchesDir",
+				extraYAML:      []string{"patchesDir: configs"},
+				mkdir:          "configs",
+				wantPatchesDir: func(d string) string { return filepath.Join(d, "configs") },
+				wantSecrets:    func(d string) string { return filepath.Join(d, "secrets.yaml") },
+			},
+			{
+				name:           "absolutePatchesDir",
+				extraYAML:      []string{"patchesDir: /abs/patches"},
+				wantPatchesDir: func(_ string) string { return "/abs/patches" },
+				wantSecrets:    func(d string) string { return filepath.Join(d, "secrets.yaml") },
+			},
+			{
+				name:           "relativeSecretsPath",
+				extraYAML:      []string{"secretsPath: mine.yaml"},
+				wantPatchesDir: func(d string) string { return d },
+				wantSecrets:    func(d string) string { return filepath.Join(d, "mine.yaml") },
+			},
+			{
+				name:           "absoluteSecretsPath",
+				extraYAML:      []string{"secretsPath: /etc/mine.yaml"},
+				wantPatchesDir: func(d string) string { return d },
+				wantSecrets:    func(_ string) string { return "/etc/mine.yaml" },
+			},
+			{
+				name:           "bothRelative",
+				extraYAML:      []string{"patchesDir: _cfg", "secretsPath: mine.yaml"},
+				mkdir:          "_cfg",
+				wantPatchesDir: func(d string) string { return filepath.Join(d, "_cfg") },
+				wantSecrets:    func(d string) string { return filepath.Join(d, "mine.yaml") },
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				sub := t.TempDir()
+				absDir, _ := filepath.Abs(sub)
+
+				if tt.mkdir != "" {
+					os.Mkdir(filepath.Join(sub, tt.mkdir), 0o755)
+				}
+
+				yaml := "clusterName: test\nclusterEndpoint: https://1.2.3.4:6443\nkubernetesVersion: 1.30.0\n"
+				for _, line := range tt.extraYAML {
+					yaml += line + "\n"
+				}
+				yaml += "nodes:\n  - host: n1\n    role: worker\n"
+
+				cfg, _, err := LoadFromFile(writeTestConfig(t, sub, yaml), "")
+				if err != nil {
+					t.Fatal(err)
+				}
+				if cfg.PatchesDir != tt.wantPatchesDir(absDir) {
+					t.Errorf("PatchesDir: got %s, want %s", cfg.PatchesDir, tt.wantPatchesDir(absDir))
+				}
+				if cfg.SecretsPath != tt.wantSecrets(absDir) {
+					t.Errorf("SecretsPath: got %s, want %s", cfg.SecretsPath, tt.wantSecrets(absDir))
+				}
+			})
+		}
+	})
+
+	t.Run("deprecatedConfigDir", func(t *testing.T) {
+		_, _, err := LoadFromFile(writeTestConfig(t, t.TempDir(), `clusterName: test
+clusterEndpoint: https://1.2.3.4:6443
+kubernetesVersion: 1.30.0
+configDir: _config
+nodes:
+  - host: n1
+    role: worker
+`), "")
+		if err == nil {
+			t.Fatal("expected error for deprecated configDir field")
+		}
+		if !strings.Contains(err.Error(), "configDir") || !strings.Contains(err.Error(), "patchesDir") {
+			t.Errorf("expected error mentioning configDir and patchesDir, got: %v", err)
+		}
+	})
+}

--- a/pkg/providers/secrets_filesystem.go
+++ b/pkg/providers/secrets_filesystem.go
@@ -7,17 +7,18 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/postfinance/topf/internal/sops"
 )
 
 // NewFilesystemSecretsProvider returns a SecretsProvider that reads and writes secrets.yaml files with optional SOPS support
-func NewFilesystemSecretsProvider() SecretsProvider {
+func NewFilesystemSecretsProvider(configDir string) SecretsProvider {
 	path := "secrets.yaml"
 
 	return &filesystemSecrets{
-		path: path,
+		path: filepath.Join(configDir, path),
 	}
 }
 

--- a/pkg/providers/secrets_filesystem.go
+++ b/pkg/providers/secrets_filesystem.go
@@ -7,18 +7,16 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 
 	"github.com/postfinance/topf/internal/sops"
 )
 
-// NewFilesystemSecretsProvider returns a SecretsProvider that reads and writes secrets.yaml files with optional SOPS support
-func NewFilesystemSecretsProvider(configDir string) SecretsProvider {
-	path := "secrets.yaml"
-
+// NewFilesystemSecretsProvider returns a SecretsProvider that reads and writes
+// secrets.yaml at the given path with optional SOPS support.
+func NewFilesystemSecretsProvider(secretsPath string) SecretsProvider {
 	return &filesystemSecrets{
-		path: filepath.Join(configDir, path),
+		path: secretsPath,
 	}
 }
 


### PR DESCRIPTION
This is a simple change that allows all talos-related config files to be located together if not in the topf.yaml directory.
