### PR TITLE
feat: implement vals-based file processing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,5 +32,12 @@ jobs:
           curl -fsSL "https://github.com/FiloSottile/age/releases/download/v${AGE_VERSION}/age-v${AGE_VERSION}-linux-amd64.tar.gz" | tar xz
           sudo mv age/age age/age-keygen /usr/local/bin/
           age --version
+      - name: Install vals
+        env:
+          VALS_VERSION: "0.44.0"
+        run: |
+          curl -fsSL "https://github.com/helmfile/vals/releases/download/v${VALS_VERSION}/vals_${VALS_VERSION}_linux_amd64.tar.gz" | tar xz vals
+          sudo mv vals /usr/local/bin/
+          vals version
       - name: Run tests
         run: go test -v -race ./...

--- a/internal/decryption/decryption.go
+++ b/internal/decryption/decryption.go
@@ -1,11 +1,16 @@
 // Copyright 2026 PostFinance AG
 // SPDX-License-Identifier: MIT
 
-// Package decryption provides a unified interface for reading encrypted files,
-// applying SOPS decryption and vals evaluation in sequence.
+// Package decryption provides a unified interface for reading files with
+// automatic SOPS decryption and vals reference evaluation.
 package decryption
 
 import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+
 	"github.com/postfinance/topf/internal/sops"
 	"github.com/postfinance/topf/internal/vals"
 )
@@ -14,15 +19,37 @@ import (
 // then evaluates any vals references. It returns the final content and
 // a combined list of plaintext secret values discovered during both
 // SOPS decryption and vals evaluation (for output redaction).
-// Returns nil content if the file doesn't exist (not an error).
-func ReadFile(path string) (content []byte, secrets []string, err error) {
-	content, sopsSecrets, err := sops.ReadFileWithSOPS(path)
+// Returns an error wrapping fs.ErrNotExist if the file doesn't exist.
+func ReadFile(path string) ([]byte, []string, error) {
+	if _, err := os.Stat(path); err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil, fmt.Errorf("read file %q: %w", path, fs.ErrNotExist)
+		}
+
+		return nil, nil, fmt.Errorf("read file %q: %w", path, err)
+	}
+
+	var (
+		content     []byte
+		sopsSecrets []string
+	)
+
+	isEncrypted, err := sops.IsEncrypted(path)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	if content == nil {
-		return nil, nil, nil
+	if isEncrypted {
+		content, sopsSecrets, err = sops.Decrypt(path)
+		if err != nil {
+			return nil, nil, err
+		}
+	} else {
+		//nolint:gosec // files read through a variable in our control
+		content, err = os.ReadFile(path)
+		if err != nil {
+			return nil, nil, err
+		}
 	}
 
 	valsContent, valsSecrets, err := vals.EvalContent(content)

--- a/internal/decryption/decryption.go
+++ b/internal/decryption/decryption.go
@@ -1,0 +1,38 @@
+// Copyright 2026 PostFinance AG
+// SPDX-License-Identifier: MIT
+
+// Package decryption provides a unified interface for reading encrypted files,
+// applying SOPS decryption and vals evaluation in sequence.
+package decryption
+
+import (
+	"github.com/postfinance/topf/internal/sops"
+	"github.com/postfinance/topf/internal/vals"
+)
+
+// ReadFile reads a file, automatically decrypts it with SOPS if encrypted,
+// then evaluates any vals references. It returns the final content and
+// a combined list of plaintext secret values discovered during both
+// SOPS decryption and vals evaluation (for output redaction).
+// Returns nil content if the file doesn't exist (not an error).
+func ReadFile(path string) (content []byte, secrets []string, err error) {
+	content, sopsSecrets, err := sops.ReadFileWithSOPS(path)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if content == nil {
+		return nil, nil, nil
+	}
+
+	valsContent, valsSecrets, err := vals.EvalContent(content)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	allSecrets := make([]string, 0, len(sopsSecrets)+len(valsSecrets))
+	allSecrets = append(allSecrets, sopsSecrets...)
+	allSecrets = append(allSecrets, valsSecrets...)
+
+	return valsContent, allSecrets, nil
+}

--- a/internal/decryption/decryption_test.go
+++ b/internal/decryption/decryption_test.go
@@ -4,22 +4,21 @@
 package decryption
 
 import (
+	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
 )
 
 func TestReadFile(t *testing.T) {
-	t.Run("non-existent file returns nil", func(t *testing.T) {
-		content, secrets, err := ReadFile("/nonexistent/path/file.yaml")
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
+	t.Run("non-existent file returns fs.ErrNotExist", func(t *testing.T) {
+		_, _, err := ReadFile("/nonexistent/path/file.yaml")
+		if err == nil {
+			t.Fatal("expected error, got nil")
 		}
-		if content != nil {
-			t.Errorf("expected nil content, got %s", content)
-		}
-		if secrets != nil {
-			t.Errorf("expected nil secrets, got %v", secrets)
+		if !errors.Is(err, fs.ErrNotExist) {
+			t.Errorf("expected fs.ErrNotExist, got: %v", err)
 		}
 	})
 

--- a/internal/decryption/decryption_test.go
+++ b/internal/decryption/decryption_test.go
@@ -1,0 +1,45 @@
+// Copyright 2026 PostFinance AG
+// SPDX-License-Identifier: MIT
+
+package decryption
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReadFile(t *testing.T) {
+	t.Run("non-existent file returns nil", func(t *testing.T) {
+		content, secrets, err := ReadFile("/nonexistent/path/file.yaml")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if content != nil {
+			t.Errorf("expected nil content, got %s", content)
+		}
+		if secrets != nil {
+			t.Errorf("expected nil secrets, got %v", secrets)
+		}
+	})
+
+	t.Run("plain file returns content without secrets", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "plain.yaml")
+
+		if err := os.WriteFile(path, []byte("foo: bar\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		content, secrets, err := ReadFile(path)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if string(content) != "foo: bar\n" {
+			t.Errorf("unexpected content: %q", string(content))
+		}
+		if len(secrets) != 0 {
+			t.Errorf("expected no secrets, got %v", secrets)
+		}
+	})
+}

--- a/internal/sops/sops.go
+++ b/internal/sops/sops.go
@@ -1,172 +1,78 @@
 // Copyright 2026 PostFinance AG
 // SPDX-License-Identifier: MIT
 
-// Package sops provides utilities for reading SOPS-encrypted files
+// Package sops provides utilities for checking SOPS encryption status
+// and decrypting SOPS-encrypted files.
 package sops
 
 import (
-	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"os/exec"
 	"strings"
 
-	"gopkg.in/yaml.v3"
+	"github.com/postfinance/topf/internal/yamlutils"
 )
 
-// ReadFileWithSOPS reads a file and automatically decrypts it with SOPS if encrypted.
-// In addition to the decrypted content, it returns the plaintext values of any fields
-// that were SOPS-encrypted (identified by the "ENC[" prefix in the encrypted file).
-// Returns nil content if the file doesn't exist (not an error).
-func ReadFileWithSOPS(path string) (content []byte, secrets []string, err error) {
-	// Check if file exists
-	_, err = os.Stat(path)
-	if os.IsNotExist(err) {
-		return nil, nil, nil
-	} else if err != nil {
-		return nil, nil, err
-	}
-
-	// Check if file is encrypted with SOPS
+// IsEncrypted checks whether a file is encrypted with SOPS by running
+// `sops filestatus`. Returns false with no error if the sops binary is
+// not available (graceful degradation). Returns an error if sops is
+// available but produces unexpected output.
+func IsEncrypted(path string) (bool, error) {
 	// #nosec G204 required as long as we don't inline sops decryption
 	statusCmd := exec.Command("sops", "filestatus", path)
-	statusOutput, statusErr := statusCmd.Output()
+	statusOutput, cmdErr := statusCmd.Output()
+
+	// sops not installed or filestatus failed — treat as not encrypted
+	//nolint:nilerr // intentional: graceful degradation when sops is unavailable
+	if cmdErr != nil {
+		return false, nil
+	}
 
 	var status struct {
 		Encrypted bool `json:"encrypted"`
 	}
 
-	isEncrypted := statusErr == nil &&
-		json.Unmarshal(statusOutput, &status) == nil &&
-		status.Encrypted
-
-	if !isEncrypted {
-		//nolint:gosec // files read through a variable in our control
-		content, err = os.ReadFile(path)
-		return content, nil, err
+	if err := json.Unmarshal(statusOutput, &status); err != nil {
+		return false, fmt.Errorf("failed to parse sops filestatus output: %w", err)
 	}
 
-	// Read encrypted content to discover which fields are encrypted
+	return status.Encrypted, nil
+}
+
+// Decrypt decrypts a SOPS-encrypted file and returns the decrypted content
+// along with the plaintext values of any SOPS-encrypted fields (identified
+// by the "ENC[" prefix) for output redaction.
+func Decrypt(path string) ([]byte, []string, error) {
+	// Read the encrypted file to discover which fields are encrypted
 	//nolint:gosec // files read through a variable in our control
 	encryptedBytes, err := os.ReadFile(path)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("failed to read encrypted file: %w", err)
 	}
 
-	// Decrypt
-	// #nosec G204 required as long as we don't inline sops encryption
+	// #nosec G204 required as long as we don't inline sops decryption
 	decryptCmd := exec.Command("sops", "decrypt", path)
 
-	content, err = decryptCmd.Output()
+	var stderr strings.Builder
+
+	decryptCmd.Stderr = &stderr
+
+	content, err := decryptCmd.Output()
 	if err != nil {
 		exitErr := &exec.ExitError{}
 		if errors.As(err, &exitErr) {
-			return nil, nil, fmt.Errorf("sops decryption failed: %s", string(exitErr.Stderr))
+			return nil, nil, fmt.Errorf("sops decryption failed: %s: %w", strings.TrimSpace(stderr.String()), err)
 		}
 
-		return nil, nil, fmt.Errorf("failed to run sops decrypt: %w", err)
+		return nil, nil, fmt.Errorf("sops decryption failed: %w", err)
 	}
 
-	secrets = extractEncryptedValues(encryptedBytes, content)
+	secrets := yamlutils.ExtractSecrets(encryptedBytes, content, func(s string) bool {
+		return strings.HasPrefix(s, "ENC[")
+	})
 
 	return content, secrets, nil
-}
-
-// extractEncryptedValues finds values that were SOPS-encrypted by comparing
-// the encrypted and decrypted YAML. It walks each document in the encrypted YAML
-// to find leaf values starting with "ENC[", records their paths, then resolves
-// those paths in the corresponding decrypted YAML document to return the plaintext values.
-func extractEncryptedValues(encrypted, decrypted []byte) []string {
-	encDec := yaml.NewDecoder(bytes.NewReader(encrypted))
-	decDec := yaml.NewDecoder(bytes.NewReader(decrypted))
-
-	var secrets []string
-
-	for {
-		var encData, decData any
-
-		encErr := encDec.Decode(&encData)
-		decErr := decDec.Decode(&decData)
-
-		if errors.Is(encErr, io.EOF) || errors.Is(decErr, io.EOF) {
-			break
-		}
-
-		if encErr != nil || decErr != nil {
-			return secrets
-		}
-
-		var paths [][]any
-		collectEncryptedPaths(encData, nil, &paths)
-
-		for _, path := range paths {
-			if val, ok := resolvePath(decData, path); ok {
-				if s, ok := val.(string); ok && s != "" {
-					secrets = append(secrets, s)
-				}
-			}
-		}
-	}
-
-	return secrets
-}
-
-// collectEncryptedPaths recursively walks a YAML structure and records the
-// path to every leaf string value that starts with "ENC[".
-func collectEncryptedPaths(data any, path []any, paths *[][]any) {
-	switch v := data.(type) {
-	case map[string]any:
-		for key, val := range v {
-			collectEncryptedPaths(val, append(path, key), paths)
-		}
-	case []any:
-		for i, val := range v {
-			collectEncryptedPaths(val, append(path, i), paths)
-		}
-	case string:
-		if strings.HasPrefix(v, "ENC[") {
-			// Copy path to avoid slice aliasing
-			p := make([]any, len(path))
-			copy(p, path)
-			*paths = append(*paths, p)
-		}
-	}
-}
-
-// resolvePath follows a sequence of map keys and slice indices to reach
-// a value in a nested YAML structure.
-func resolvePath(data any, path []any) (any, bool) {
-	current := data
-
-	for _, segment := range path {
-		switch key := segment.(type) {
-		// string means we look up a key in a map
-		case string:
-			m, ok := current.(map[string]any)
-			if !ok {
-				return nil, false
-			}
-
-			current, ok = m[key]
-			if !ok {
-				return nil, false
-			}
-
-		// integer means we index into a slice
-		case int:
-			s, ok := current.([]any)
-			if !ok || key >= len(s) {
-				return nil, false
-			}
-
-			current = s[key]
-		default:
-			return nil, false
-		}
-	}
-
-	return current, true
 }

--- a/internal/sops/sops_test.go
+++ b/internal/sops/sops_test.go
@@ -8,110 +8,74 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"sort"
 	"strings"
 	"testing"
 )
 
-func TestCollectEncryptedPaths(t *testing.T) {
-	data := map[string]any{
-		"plain":  "hello",
-		"secret": "ENC[AES256_GCM,data:abc,type:str]",
-		"nested": map[string]any{
-			"deep":   "ENC[AES256_GCM,data:xyz,type:str]",
-			"normal": "world",
-		},
-		"list": []any{
-			"normal",
-			"ENC[AES256_GCM,data:123,type:str]",
-			map[string]any{
-				"inner": "ENC[AES256_GCM,data:456,type:str]",
-			},
-		},
-		"empty":   "",
-		"numeric": 42,
-		"nil_val": nil,
+func TestIsEncrypted(t *testing.T) {
+	out, err := exec.Command("age-keygen").CombinedOutput()
+	if err != nil {
+		t.Fatal(err)
 	}
 
-	var paths [][]any
-	collectEncryptedPaths(data, nil, &paths)
-
-	got := make([]string, len(paths))
-	for i, p := range paths {
-		parts := make([]string, len(p))
-		for j, seg := range p {
-			parts[j] = fmt.Sprintf("%v", seg)
+	var publicKey, secretKey string
+	for _, line := range strings.Split(string(out), "\n") {
+		if strings.HasPrefix(line, "# public key: ") {
+			publicKey = strings.TrimPrefix(line, "# public key: ")
 		}
-		got[i] = strings.Join(parts, ".")
-	}
-	sort.Strings(got)
-
-	want := []string{
-		"list.1",
-		"list.2.inner",
-		"nested.deep",
-		"secret",
-	}
-
-	if len(got) != len(want) {
-		t.Fatalf("expected %d paths, got %d: %v", len(want), len(got), got)
-	}
-	for i := range want {
-		if got[i] != want[i] {
-			t.Errorf("path[%d]: want %q, got %q", i, want[i], got[i])
+		if strings.HasPrefix(line, "AGE-SECRET-KEY-") {
+			secretKey = strings.TrimSpace(line)
 		}
 	}
+	t.Setenv("SOPS_AGE_KEY", secretKey)
+
+	t.Run("plaintext file returns false", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "plain.yaml")
+		if err := os.WriteFile(path, []byte("foo: bar\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		encrypted, err := IsEncrypted(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if encrypted {
+			t.Error("plaintext file should not be detected as encrypted")
+		}
+	})
+
+	t.Run("encrypted file returns true", func(t *testing.T) {
+		dir := t.TempDir()
+
+		sopsConfig := fmt.Sprintf("creation_rules:\n  - age: %s\n", publicKey)
+		if err := os.WriteFile(filepath.Join(dir, ".sops.yaml"), []byte(sopsConfig), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		content := "secret: myvalue\n"
+		path := filepath.Join(dir, "secrets.yaml")
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		configPath := filepath.Join(dir, ".sops.yaml")
+		cmd := exec.Command("sops", "--config", configPath, "encrypt", "--in-place", path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("sops encrypt: %s: %s", err, out)
+		}
+
+		encrypted, err := IsEncrypted(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !encrypted {
+			t.Error("encrypted file should be detected as encrypted")
+		}
+	})
 }
 
-func TestResolvePath(t *testing.T) {
-	data := map[string]any{
-		"a": map[string]any{
-			"b": "deep-value",
-		},
-		"list": []any{
-			"first",
-			map[string]any{"key": "nested-in-list"},
-		},
-		"top": "top-value",
-	}
-
-	tests := []struct {
-		name   string
-		path   []any
-		want   any
-		wantOk bool
-	}{
-		{"nested map", []any{"a", "b"}, "deep-value", true},
-		{"top level", []any{"top"}, "top-value", true},
-		{"list index", []any{"list", 0}, "first", true},
-		{"list nested map", []any{"list", 1, "key"}, "nested-in-list", true},
-		{"missing key", []any{"nonexistent"}, nil, false},
-		{"index on map", []any{"a", 0}, nil, false},
-		{"key on list", []any{"list", "nope"}, nil, false},
-		{"index out of bounds", []any{"list", 99}, nil, false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, ok := resolvePath(data, tt.path)
-			if ok != tt.wantOk {
-				t.Fatalf("ok = %v, want %v", ok, tt.wantOk)
-			}
-			if ok && got != tt.want {
-				t.Errorf("got %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func TestReadFileWithSOPS(t *testing.T) {
-	if _, err := exec.LookPath("sops"); err != nil {
-		t.Skip("sops not in PATH")
-	}
-	if _, err := exec.LookPath("age-keygen"); err != nil {
-		t.Skip("age-keygen not in PATH")
-	}
-
+func TestDecrypt(t *testing.T) {
 	out, err := exec.Command("age-keygen").CombinedOutput()
 	if err != nil {
 		t.Fatal(err)
@@ -171,7 +135,7 @@ certs:
 			t.Fatalf("sops encrypt: %s: %s", err, out)
 		}
 
-		content, secrets, err := ReadFileWithSOPS(secretsPath)
+		content, secrets, err := Decrypt(secretsPath)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -239,7 +203,7 @@ nodes:
 			t.Fatalf("sops encrypt: %s: %s", err, out)
 		}
 
-		content, secrets, err := ReadFileWithSOPS(topfPath)
+		content, secrets, err := Decrypt(topfPath)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/vals/vals.go
+++ b/internal/vals/vals.go
@@ -1,0 +1,189 @@
+// Copyright 2026 PostFinance AG
+// SPDX-License-Identifier: MIT
+
+// Package vals provides utilities for evaluating vals references in YAML content
+package vals
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os/exec"
+	"regexp"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// refPattern matches vals reference expressions like ref+vault://..., ref+sops://..., etc.
+var refPattern = regexp.MustCompile(`^ref\+[a-zA-Z0-9]+://`)
+
+// EvalContent evaluates vals references in YAML content by piping it through
+// the vals binary. It returns the evaluated content and a list of plaintext
+// values that were resolved from vals references (for output redaction).
+// If the vals binary is not found, the content is returned unchanged.
+func EvalContent(content []byte) ([]byte, []string, error) {
+	// Check if content contains any vals references before spawning a process
+	if !hasValsRefs(content) {
+		return content, nil, nil
+	}
+
+	// #nosec G204 required as long as we don't inline vals evaluation
+	cmd := exec.Command("vals", "eval", "-f", "-")
+
+	cmd.Stdin = bytes.NewReader(content)
+
+	var stdout, stderr bytes.Buffer
+
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		return nil, nil, fmt.Errorf("vals evaluation failed: %s", strings.TrimSpace(stderr.String()))
+	}
+
+	evaluated := stdout.Bytes()
+	secrets := extractValsSecrets(content, evaluated)
+
+	return evaluated, secrets, nil
+}
+
+// hasValsRefs checks whether the content contains any vals reference patterns.
+func hasValsRefs(content []byte) bool {
+	dec := yaml.NewDecoder(bytes.NewReader(content))
+
+	for {
+		var doc any
+
+		if err := dec.Decode(&doc); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+
+			return false
+		}
+
+		if doc != nil && containsValsRef(doc) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// containsValsRef recursively checks if a YAML structure contains any vals ref.
+func containsValsRef(data any) bool {
+	switch v := data.(type) {
+	case map[string]any:
+		for _, val := range v {
+			if containsValsRef(val) {
+				return true
+			}
+		}
+	case []any:
+		for _, val := range v {
+			if containsValsRef(val) {
+				return true
+			}
+		}
+	case string:
+		return refPattern.MatchString(v)
+	}
+
+	return false
+}
+
+// extractValsSecrets finds values that were vals-references by comparing
+// the pre-evaluated and post-evaluated YAML. It walks each document in the
+// pre-evaluated YAML to find leaf values matching the ref+ pattern, records
+// their paths, then resolves those paths in the post-evaluated YAML to
+// return the plaintext values.
+func extractValsSecrets(preEval, postEval []byte) []string {
+	preDec := yaml.NewDecoder(bytes.NewReader(preEval))
+	postDec := yaml.NewDecoder(bytes.NewReader(postEval))
+
+	var secrets []string
+
+	for {
+		var preData, postData any
+
+		preErr := preDec.Decode(&preData)
+		postErr := postDec.Decode(&postData)
+
+		if errors.Is(preErr, io.EOF) || errors.Is(postErr, io.EOF) {
+			break
+		}
+
+		if preErr != nil || postErr != nil {
+			return secrets
+		}
+
+		var paths [][]any
+		collectValsPaths(preData, nil, &paths)
+
+		for _, path := range paths {
+			if val, ok := resolvePath(postData, path); ok {
+				if s, ok := val.(string); ok && s != "" {
+					secrets = append(secrets, s)
+				}
+			}
+		}
+	}
+
+	return secrets
+}
+
+// collectValsPaths recursively walks a YAML structure and records the
+// path to every leaf string value that matches the vals ref pattern.
+func collectValsPaths(data any, path []any, paths *[][]any) {
+	switch v := data.(type) {
+	case map[string]any:
+		for key, val := range v {
+			collectValsPaths(val, append(path, key), paths)
+		}
+	case []any:
+		for i, val := range v {
+			collectValsPaths(val, append(path, i), paths)
+		}
+	case string:
+		if refPattern.MatchString(v) {
+			p := make([]any, len(path))
+			copy(p, path)
+			*paths = append(*paths, p)
+		}
+	}
+}
+
+// resolvePath follows a sequence of map keys and slice indices to reach
+// a value in a nested YAML structure.
+func resolvePath(data any, path []any) (any, bool) {
+	current := data
+
+	for _, segment := range path {
+		switch key := segment.(type) {
+		case string:
+			m, ok := current.(map[string]any)
+			if !ok {
+				return nil, false
+			}
+
+			current, ok = m[key]
+			if !ok {
+				return nil, false
+			}
+
+		case int:
+			s, ok := current.([]any)
+			if !ok || key >= len(s) {
+				return nil, false
+			}
+
+			current = s[key]
+		default:
+			return nil, false
+		}
+	}
+
+	return current, true
+}

--- a/internal/vals/vals.go
+++ b/internal/vals/vals.go
@@ -11,8 +11,10 @@ import (
 	"io"
 	"os/exec"
 	"regexp"
+	"slices"
 	"strings"
 
+	"github.com/postfinance/topf/internal/yamlutils"
 	"gopkg.in/yaml.v3"
 )
 
@@ -22,15 +24,20 @@ var refPattern = regexp.MustCompile(`^ref\+[a-zA-Z0-9]+://`)
 // EvalContent evaluates vals references in YAML content by piping it through
 // the vals binary. It returns the evaluated content and a list of plaintext
 // values that were resolved from vals references (for output redaction).
-// If the vals binary is not found, the content is returned unchanged.
+// Returns an error if the content contains vals references but the vals
+// binary is not installed.
 func EvalContent(content []byte) ([]byte, []string, error) {
-	// Check if content contains any vals references before spawning a process
 	if !hasValsRefs(content) {
 		return content, nil, nil
 	}
 
+	valsPath, err := exec.LookPath("vals")
+	if err != nil {
+		return nil, nil, fmt.Errorf("content contains vals references but vals binary not found in PATH: %w", err)
+	}
+
 	// #nosec G204 required as long as we don't inline vals evaluation
-	cmd := exec.Command("vals", "eval", "-f", "-")
+	cmd := exec.Command(valsPath, "eval", "-f", "-")
 
 	cmd.Stdin = bytes.NewReader(content)
 
@@ -40,11 +47,11 @@ func EvalContent(content []byte) ([]byte, []string, error) {
 	cmd.Stderr = &stderr
 
 	if err := cmd.Run(); err != nil {
-		return nil, nil, fmt.Errorf("vals evaluation failed: %s", strings.TrimSpace(stderr.String()))
+		return nil, nil, fmt.Errorf("vals evaluation failed: %s: %w", strings.TrimSpace(stderr.String()), err)
 	}
 
 	evaluated := stdout.Bytes()
-	secrets := extractValsSecrets(content, evaluated)
+	secrets := yamlutils.ExtractSecrets(content, evaluated, refPattern.MatchString)
 
 	return evaluated, secrets, nil
 }
@@ -82,108 +89,12 @@ func containsValsRef(data any) bool {
 			}
 		}
 	case []any:
-		for _, val := range v {
-			if containsValsRef(val) {
-				return true
-			}
+		if slices.ContainsFunc(v, containsValsRef) {
+			return true
 		}
 	case string:
 		return refPattern.MatchString(v)
 	}
 
 	return false
-}
-
-// extractValsSecrets finds values that were vals-references by comparing
-// the pre-evaluated and post-evaluated YAML. It walks each document in the
-// pre-evaluated YAML to find leaf values matching the ref+ pattern, records
-// their paths, then resolves those paths in the post-evaluated YAML to
-// return the plaintext values.
-func extractValsSecrets(preEval, postEval []byte) []string {
-	preDec := yaml.NewDecoder(bytes.NewReader(preEval))
-	postDec := yaml.NewDecoder(bytes.NewReader(postEval))
-
-	var secrets []string
-
-	for {
-		var preData, postData any
-
-		preErr := preDec.Decode(&preData)
-		postErr := postDec.Decode(&postData)
-
-		if errors.Is(preErr, io.EOF) || errors.Is(postErr, io.EOF) {
-			break
-		}
-
-		if preErr != nil || postErr != nil {
-			return secrets
-		}
-
-		var paths [][]any
-		collectValsPaths(preData, nil, &paths)
-
-		for _, path := range paths {
-			if val, ok := resolvePath(postData, path); ok {
-				if s, ok := val.(string); ok && s != "" {
-					secrets = append(secrets, s)
-				}
-			}
-		}
-	}
-
-	return secrets
-}
-
-// collectValsPaths recursively walks a YAML structure and records the
-// path to every leaf string value that matches the vals ref pattern.
-func collectValsPaths(data any, path []any, paths *[][]any) {
-	switch v := data.(type) {
-	case map[string]any:
-		for key, val := range v {
-			collectValsPaths(val, append(path, key), paths)
-		}
-	case []any:
-		for i, val := range v {
-			collectValsPaths(val, append(path, i), paths)
-		}
-	case string:
-		if refPattern.MatchString(v) {
-			p := make([]any, len(path))
-			copy(p, path)
-			*paths = append(*paths, p)
-		}
-	}
-}
-
-// resolvePath follows a sequence of map keys and slice indices to reach
-// a value in a nested YAML structure.
-func resolvePath(data any, path []any) (any, bool) {
-	current := data
-
-	for _, segment := range path {
-		switch key := segment.(type) {
-		case string:
-			m, ok := current.(map[string]any)
-			if !ok {
-				return nil, false
-			}
-
-			current, ok = m[key]
-			if !ok {
-				return nil, false
-			}
-
-		case int:
-			s, ok := current.([]any)
-			if !ok || key >= len(s) {
-				return nil, false
-			}
-
-			current = s[key]
-		default:
-			return nil, false
-		}
-	}
-
-	return current, true
 }

--- a/internal/vals/vals_test.go
+++ b/internal/vals/vals_test.go
@@ -1,0 +1,239 @@
+// Copyright 2026 PostFinance AG
+// SPDX-License-Identifier: MIT
+
+package vals
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+func TestHasValsRefs(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{
+			name:    "no refs",
+			content: "foo: bar\nbaz: qux\n",
+			want:    false,
+		},
+		{
+			name:    "has vault ref",
+			content: "foo: ref+vault://secret/data/foo#/bar\n",
+			want:    true,
+		},
+		{
+			name:    "has sops ref",
+			content: "foo: ref+sops://path/to/file#/key\n",
+			want:    true,
+		},
+		{
+			name:    "has awsssm ref",
+			content: "foo: ref+awsssm://my/param\n",
+			want:    true,
+		},
+		{
+			name:    "ref in nested map",
+			content: "nested:\n  deep: ref+vault://secret/data/foo#/bar\n",
+			want:    true,
+		},
+		{
+			name:    "ref in list",
+			content: "items:\n  - ref+vault://secret/data/foo#/bar\n",
+			want:    true,
+		},
+		{
+			name:    "plain string with ref not at start",
+			content: "foo: something ref+vault://secret/data/foo#/bar more\n",
+			want:    false,
+		},
+		{
+			name:    "string starting with ref but no provider",
+			content: "foo: ref+noprovider\n",
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := hasValsRefs([]byte(tt.content))
+			if got != tt.want {
+				t.Errorf("hasValsRefs() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCollectValsPaths(t *testing.T) {
+	data := map[string]any{
+		"plain":     "hello",
+		"vault_ref": "ref+vault://secret/data/foo#/bar",
+		"nested": map[string]any{
+			"deep":    "ref+sops://path/to/file#/key",
+			"normal":  "world",
+		},
+		"list": []any{
+			"normal",
+			"ref+awsssm://my/param",
+			map[string]any{
+				"inner": "ref+vault://secret/data/baz#/qux",
+			},
+		},
+		"empty":   "",
+		"numeric": 42,
+		"nil_val": nil,
+	}
+
+	var paths [][]any
+	collectValsPaths(data, nil, &paths)
+
+	got := make([]string, len(paths))
+	for i, p := range paths {
+		parts := make([]string, len(p))
+		for j, seg := range p {
+			parts[j] = fmt.Sprintf("%v", seg)
+		}
+		got[i] = strings.Join(parts, ".")
+	}
+	sort.Strings(got)
+
+	want := []string{
+		"list.1",
+		"list.2.inner",
+		"nested.deep",
+		"vault_ref",
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("expected %d paths, got %d: %v", len(want), len(got), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("path[%d]: want %q, got %q", i, want[i], got[i])
+		}
+	}
+}
+
+func TestResolvePath(t *testing.T) {
+	data := map[string]any{
+		"a": map[string]any{
+			"b": "deep-value",
+		},
+		"list": []any{
+			"first",
+			map[string]any{"key": "nested-in-list"},
+		},
+		"top": "top-value",
+	}
+
+	tests := []struct {
+		name   string
+		path   []any
+		want   any
+		wantOk bool
+	}{
+		{"nested map", []any{"a", "b"}, "deep-value", true},
+		{"top level", []any{"top"}, "top-value", true},
+		{"list index", []any{"list", 0}, "first", true},
+		{"list nested map", []any{"list", 1, "key"}, "nested-in-list", true},
+		{"missing key", []any{"nonexistent"}, nil, false},
+		{"index on map", []any{"a", 0}, nil, false},
+		{"key on list", []any{"list", "nope"}, nil, false},
+		{"index out of bounds", []any{"list", 99}, nil, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := resolvePath(data, tt.path)
+			if ok != tt.wantOk {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOk)
+			}
+			if ok && got != tt.want {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEvalContent(t *testing.T) {
+	if _, err := exec.LookPath("vals"); err != nil {
+		t.Skip("vals not in PATH")
+	}
+
+	t.Run("no vals refs returns content unchanged", func(t *testing.T) {
+		input := []byte("foo: bar\nbaz: 42\n")
+		gotContent, secrets, err := EvalContent(input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(gotContent) != string(input) {
+			t.Errorf("content should be unchanged when no refs present")
+		}
+		if len(secrets) != 0 {
+			t.Errorf("expected no secrets, got %v", secrets)
+		}
+	})
+
+	t.Run("echo provider resolves refs", func(t *testing.T) {
+		dir := t.TempDir()
+
+		secretFile := filepath.Join(dir, "mysecret")
+		if err := writefile(secretFile, "plaintext-value"); err != nil {
+			t.Fatal(err)
+		}
+
+		input := []byte(fmt.Sprintf("foo: ref+file://%s\nbar: plain-value\n", secretFile))
+		content, secrets, err := EvalContent(input)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		contentStr := string(content)
+		if !strings.Contains(contentStr, "plaintext-value") {
+			t.Errorf("vals-evaluated content missing resolved secret, got: %s", contentStr)
+		}
+		if !strings.Contains(contentStr, "plain-value") {
+			t.Errorf("vals-evaluated content missing plain value, got: %s", contentStr)
+		}
+
+		if len(secrets) != 1 {
+			t.Fatalf("expected 1 secret, got %d: %v", len(secrets), secrets)
+		}
+		if secrets[0] != "plaintext-value" {
+			t.Errorf("secret = %q, want %q", secrets[0], "plaintext-value")
+		}
+	})
+
+	t.Run("nested vals refs", func(t *testing.T) {
+		dir := t.TempDir()
+
+		secretFile := filepath.Join(dir, "nestedsecret")
+		if err := writefile(secretFile, "deep-secret"); err != nil {
+			t.Fatal(err)
+		}
+
+		input := []byte(fmt.Sprintf("level1:\n  level2: ref+file://%s\n", secretFile))
+		_, secrets, err := EvalContent(input)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(secrets) != 1 {
+			t.Fatalf("expected 1 secret, got %d: %v", len(secrets), secrets)
+		}
+		if secrets[0] != "deep-secret" {
+			t.Errorf("secret = %q, want %q", secrets[0], "deep-secret")
+		}
+	})
+}
+
+func writefile(path, content string) error {
+	return os.WriteFile(path, []byte(content), 0o644)
+}

--- a/internal/vals/vals_test.go
+++ b/internal/vals/vals_test.go
@@ -6,9 +6,7 @@ package vals
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
-	"sort"
 	"strings"
 	"testing"
 )
@@ -71,102 +69,7 @@ func TestHasValsRefs(t *testing.T) {
 	}
 }
 
-func TestCollectValsPaths(t *testing.T) {
-	data := map[string]any{
-		"plain":     "hello",
-		"vault_ref": "ref+vault://secret/data/foo#/bar",
-		"nested": map[string]any{
-			"deep":    "ref+sops://path/to/file#/key",
-			"normal":  "world",
-		},
-		"list": []any{
-			"normal",
-			"ref+awsssm://my/param",
-			map[string]any{
-				"inner": "ref+vault://secret/data/baz#/qux",
-			},
-		},
-		"empty":   "",
-		"numeric": 42,
-		"nil_val": nil,
-	}
-
-	var paths [][]any
-	collectValsPaths(data, nil, &paths)
-
-	got := make([]string, len(paths))
-	for i, p := range paths {
-		parts := make([]string, len(p))
-		for j, seg := range p {
-			parts[j] = fmt.Sprintf("%v", seg)
-		}
-		got[i] = strings.Join(parts, ".")
-	}
-	sort.Strings(got)
-
-	want := []string{
-		"list.1",
-		"list.2.inner",
-		"nested.deep",
-		"vault_ref",
-	}
-
-	if len(got) != len(want) {
-		t.Fatalf("expected %d paths, got %d: %v", len(want), len(got), got)
-	}
-	for i := range want {
-		if got[i] != want[i] {
-			t.Errorf("path[%d]: want %q, got %q", i, want[i], got[i])
-		}
-	}
-}
-
-func TestResolvePath(t *testing.T) {
-	data := map[string]any{
-		"a": map[string]any{
-			"b": "deep-value",
-		},
-		"list": []any{
-			"first",
-			map[string]any{"key": "nested-in-list"},
-		},
-		"top": "top-value",
-	}
-
-	tests := []struct {
-		name   string
-		path   []any
-		want   any
-		wantOk bool
-	}{
-		{"nested map", []any{"a", "b"}, "deep-value", true},
-		{"top level", []any{"top"}, "top-value", true},
-		{"list index", []any{"list", 0}, "first", true},
-		{"list nested map", []any{"list", 1, "key"}, "nested-in-list", true},
-		{"missing key", []any{"nonexistent"}, nil, false},
-		{"index on map", []any{"a", 0}, nil, false},
-		{"key on list", []any{"list", "nope"}, nil, false},
-		{"index out of bounds", []any{"list", 99}, nil, false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, ok := resolvePath(data, tt.path)
-			if ok != tt.wantOk {
-				t.Fatalf("ok = %v, want %v", ok, tt.wantOk)
-			}
-			if ok && got != tt.want {
-				t.Errorf("got %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
 func TestEvalContent(t *testing.T) {
-	if _, err := exec.LookPath("vals"); err != nil {
-		t.Skip("vals not in PATH")
-	}
-
 	t.Run("no vals refs returns content unchanged", func(t *testing.T) {
 		input := []byte("foo: bar\nbaz: 42\n")
 		gotContent, secrets, err := EvalContent(input)
@@ -185,7 +88,7 @@ func TestEvalContent(t *testing.T) {
 		dir := t.TempDir()
 
 		secretFile := filepath.Join(dir, "mysecret")
-		if err := writefile(secretFile, "plaintext-value"); err != nil {
+		if err := os.WriteFile(secretFile, []byte("plaintext-value"), 0o644); err != nil {
 			t.Fatal(err)
 		}
 
@@ -215,7 +118,7 @@ func TestEvalContent(t *testing.T) {
 		dir := t.TempDir()
 
 		secretFile := filepath.Join(dir, "nestedsecret")
-		if err := writefile(secretFile, "deep-secret"); err != nil {
+		if err := os.WriteFile(secretFile, []byte("deep-secret"), 0o644); err != nil {
 			t.Fatal(err)
 		}
 
@@ -232,8 +135,4 @@ func TestEvalContent(t *testing.T) {
 			t.Errorf("secret = %q, want %q", secrets[0], "deep-secret")
 		}
 	})
-}
-
-func writefile(path, content string) error {
-	return os.WriteFile(path, []byte(content), 0o644)
 }

--- a/internal/yamlutils/yamlutils.go
+++ b/internal/yamlutils/yamlutils.go
@@ -1,0 +1,109 @@
+// Copyright 2026 PostFinance AG
+// SPDX-License-Identifier: MIT
+
+// Package yamlutils provides shared YAML utilities for walking nested structures
+// and extracting values by path. It is used by the sops and vals packages to
+// discover secret values for output redaction.
+package yamlutils
+
+import (
+	"bytes"
+	"errors"
+	"io"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ResolvePath follows a sequence of map keys (string) and slice indices (int)
+// to reach a value in a nested YAML structure.
+func ResolvePath(data any, path []any) (any, bool) {
+	current := data
+
+	for _, segment := range path {
+		switch key := segment.(type) {
+		case string:
+			m, ok := current.(map[string]any)
+			if !ok {
+				return nil, false
+			}
+
+			current, ok = m[key]
+			if !ok {
+				return nil, false
+			}
+
+		case int:
+			s, ok := current.([]any)
+			if !ok || key >= len(s) {
+				return nil, false
+			}
+
+			current = s[key]
+		default:
+			return nil, false
+		}
+	}
+
+	return current, true
+}
+
+// CollectPaths recursively walks a YAML structure and records the path to every
+// leaf string value for which the predicate returns true. Paths are copied to
+// avoid slice aliasing.
+func CollectPaths(data any, path []any, paths *[][]any, predicate func(string) bool) {
+	switch v := data.(type) {
+	case map[string]any:
+		for key, val := range v {
+			CollectPaths(val, append(path, key), paths, predicate)
+		}
+	case []any:
+		for i, val := range v {
+			CollectPaths(val, append(path, i), paths, predicate)
+		}
+	case string:
+		if predicate(v) {
+			p := make([]any, len(path))
+			copy(p, path)
+			*paths = append(*paths, p)
+		}
+	}
+}
+
+// ExtractSecrets walks paired YAML documents (before and after transformation)
+// and returns the plaintext values at every path where the "before" document
+// has a leaf string matching the predicate. This is used to collect secret
+// values for output redaction after SOPS decryption or vals evaluation.
+func ExtractSecrets(before, after []byte, predicate func(string) bool) []string {
+	beforeDec := yaml.NewDecoder(bytes.NewReader(before))
+	afterDec := yaml.NewDecoder(bytes.NewReader(after))
+
+	var secrets []string
+
+	for {
+		var beforeData, afterData any
+
+		beforeErr := beforeDec.Decode(&beforeData)
+		afterErr := afterDec.Decode(&afterData)
+
+		if errors.Is(beforeErr, io.EOF) || errors.Is(afterErr, io.EOF) {
+			break
+		}
+
+		if beforeErr != nil || afterErr != nil {
+			return secrets
+		}
+
+		var paths [][]any
+		CollectPaths(beforeData, nil, &paths, predicate)
+
+		for _, path := range paths {
+			if val, ok := ResolvePath(afterData, path); ok {
+				if s, ok := val.(string); ok && s != "" {
+					secrets = append(secrets, s)
+				}
+			}
+		}
+	}
+
+	return secrets
+}

--- a/internal/yamlutils/yamlutils_test.go
+++ b/internal/yamlutils/yamlutils_test.go
@@ -1,0 +1,120 @@
+// Copyright 2026 PostFinance AG
+// SPDX-License-Identifier: MIT
+
+package yamlutils
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+)
+
+func TestResolvePath(t *testing.T) {
+	data := map[string]any{
+		"a": map[string]any{
+			"b": "deep-value",
+		},
+		"list": []any{
+			"first",
+			map[string]any{"key": "nested-in-list"},
+		},
+		"top": "top-value",
+	}
+
+	tests := []struct {
+		name   string
+		path   []any
+		want   any
+		wantOk bool
+	}{
+		{"nested map", []any{"a", "b"}, "deep-value", true},
+		{"top level", []any{"top"}, "top-value", true},
+		{"list index", []any{"list", 0}, "first", true},
+		{"list nested map", []any{"list", 1, "key"}, "nested-in-list", true},
+		{"missing key", []any{"nonexistent"}, nil, false},
+		{"index on map", []any{"a", 0}, nil, false},
+		{"key on list", []any{"list", "nope"}, nil, false},
+		{"index out of bounds", []any{"list", 99}, nil, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := ResolvePath(data, tt.path)
+			if ok != tt.wantOk {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOk)
+			}
+			if ok && got != tt.want {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCollectPaths(t *testing.T) {
+	data := map[string]any{
+		"plain":  "hello",
+		"secret": "ENC[AES256_GCM,data:abc,type=str]",
+		"nested": map[string]any{
+			"deep":   "ENC[AES256_GCM,data:xyz,type=str]",
+			"normal": "world",
+		},
+		"list": []any{
+			"normal",
+			"ENC[AES256_GCM,data:123,type=str]",
+			map[string]any{
+				"inner": "ENC[AES256_GCM,data:456,type=str]",
+			},
+		},
+		"empty":   "",
+		"numeric": 42,
+		"nil_val": nil,
+	}
+
+	var paths [][]any
+	CollectPaths(data, nil, &paths, func(s string) bool {
+		return strings.HasPrefix(s, "ENC[")
+	})
+
+	got := make([]string, len(paths))
+	for i, p := range paths {
+		parts := make([]string, len(p))
+		for j, seg := range p {
+			parts[j] = fmt.Sprintf("%v", seg)
+		}
+		got[i] = strings.Join(parts, ".")
+	}
+	sort.Strings(got)
+
+	want := []string{
+		"list.1",
+		"list.2.inner",
+		"nested.deep",
+		"secret",
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("expected %d paths, got %d: %v", len(want), len(got), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("path[%d]: want %q, got %q", i, want[i], got[i])
+		}
+	}
+}
+
+func TestExtractSecrets(t *testing.T) {
+	before := []byte("key: ENC[data]\nother: plain\n")
+	after := []byte("key: secret-value\nother: plain\n")
+
+	secrets := ExtractSecrets(before, after, func(s string) bool {
+		return strings.HasPrefix(s, "ENC[")
+	})
+
+	if len(secrets) != 1 {
+		t.Fatalf("expected 1 secret, got %d: %v", len(secrets), secrets)
+	}
+	if secrets[0] != "secret-value" {
+		t.Errorf("secret = %q, want %q", secrets[0], "secret-value")
+	}
+}

--- a/pkg/config/patches.go
+++ b/pkg/config/patches.go
@@ -179,10 +179,6 @@ func (p *PatchContext) loadFile(filename string) ([]byte, []string, error) {
 		if err != nil {
 			return nil, nil, err
 		}
-
-		if content == nil {
-			return nil, nil, fmt.Errorf("patch file not found: %s", filename)
-		}
 	}
 
 	return content, secrets, nil

--- a/pkg/config/patches.go
+++ b/pkg/config/patches.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/postfinance/topf/internal/sops"
+	"github.com/postfinance/topf/internal/decryption"
 	"github.com/siderolabs/talos/pkg/machinery/config/configpatcher"
 	"gopkg.in/yaml.v3"
 )
@@ -175,7 +175,7 @@ func (p *PatchContext) loadFile(filename string) ([]byte, []string, error) {
 			return nil, nil, err
 		}
 	} else {
-		content, secrets, err = sops.ReadFileWithSOPS(filename)
+		content, secrets, err = decryption.ReadFile(filename)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/pkg/config/topf_config.go
+++ b/pkg/config/topf_config.go
@@ -70,10 +70,6 @@ func LoadFromFile(path string, nodesRegexFilter string) (config *TopfConfig, sec
 		return nil, nil, fmt.Errorf("failed to read config file: %w", err)
 	}
 
-	if content == nil {
-		return nil, nil, fmt.Errorf("config file not found: %s", path)
-	}
-
 	config = &TopfConfig{}
 
 	err = yaml.Unmarshal(content, config)

--- a/pkg/config/topf_config.go
+++ b/pkg/config/topf_config.go
@@ -11,7 +11,7 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/postfinance/topf/internal/sops"
+	"github.com/postfinance/topf/internal/decryption"
 	"github.com/postfinance/topf/pkg/providers"
 	"go.yaml.in/yaml/v4"
 )
@@ -65,7 +65,7 @@ func LoadFromFile(path string, nodesRegexFilter string) (config *TopfConfig, sec
 	// Read file with automatic SOPS decryption if needed
 	var content []byte
 
-	content, secrets, err = sops.ReadFileWithSOPS(path)
+	content, secrets, err = decryption.ReadFile(path)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to read config file: %w", err)
 	}

--- a/pkg/providers/secrets_filesystem.go
+++ b/pkg/providers/secrets_filesystem.go
@@ -9,7 +9,7 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/postfinance/topf/internal/sops"
+	"github.com/postfinance/topf/internal/decryption"
 )
 
 // NewFilesystemSecretsProvider returns a SecretsProvider that reads and writes
@@ -25,7 +25,7 @@ type filesystemSecrets struct {
 }
 
 func (s *filesystemSecrets) Get(_ string) ([]byte, error) {
-	content, _, err := sops.ReadFileWithSOPS(s.path)
+	content, _, err := decryption.ReadFile(s.path)
 	return content, err
 }
 


### PR DESCRIPTION
every file processed by topf (secrets.yaml, topf.yaml, patches/) is now
both being SOPS decrypted (as was the case already) and vals-decrypted.

cf #69 