### PR TITLE
feat(template): add dns1123 func for label-safe values

### DIFF
--- a/pkg/config/dns1123_test.go
+++ b/pkg/config/dns1123_test.go
@@ -1,0 +1,46 @@
+// Copyright 2026 PostFinance AG
+// SPDX-License-Identifier: MIT
+
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDns1123Label(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain", "main", "main"},
+		{"dotted version", "v1.2.3", "v1.2.3"},
+		{"slash in git ref", "feat/kube-bench-1-2-5-kubelet-ca", "feat-kube-bench-1-2-5-kubelet-ca"},
+		{"underscore and dot kept", "feature/ABC_123.x", "feature-ABC_123.x"},
+		{"leading and trailing separators trimmed", "/leading/slash/", "leading-slash"},
+		{"only invalid chars", "///", ""},
+		{"empty", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := dns1123Label(tt.in); got != tt.want {
+				t.Errorf("dns1123Label(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDns1123LabelTruncatesAndTrims(t *testing.T) {
+	in := "x/" + strings.Repeat("a", 80)
+
+	got := dns1123Label(in)
+	if len(got) > 63 {
+		t.Errorf("dns1123Label(%q) length = %d, want <= 63", in, len(got))
+	}
+
+	if strings.HasPrefix(got, "-") || strings.HasSuffix(got, "-") {
+		t.Errorf("dns1123Label(%q) = %q, must not start or end with %q", in, got, "-")
+	}
+}

--- a/pkg/config/patches.go
+++ b/pkg/config/patches.go
@@ -139,8 +139,28 @@ func (p *PatchContext) loadFolder(folder string) ([]configpatcher.Patch, []strin
 	return patches, secrets, nil
 }
 
+var (
+	dns1123InvalidChars = regexp.MustCompile(`[^A-Za-z0-9_.-]`)
+	dns1123EdgeChars    = regexp.MustCompile(`^[^A-Za-z0-9]+|[^A-Za-z0-9]+$`)
+)
+
+// dns1123Label normalizes s into a valid Kubernetes label value (RFC 1123):
+// disallowed characters are replaced with '-', the result is truncated to 63
+// characters, and leading/trailing non-alphanumeric characters are trimmed.
+// This makes values such as git refs (e.g. "feat/foo") safe to use as labels.
+func dns1123Label(s string) string {
+	s = dns1123InvalidChars.ReplaceAllString(s, "-")
+	if len(s) > 63 {
+		s = s[:63]
+	}
+
+	return dns1123EdgeChars.ReplaceAllString(s, "")
+}
+
 // RenderTemplate renders a Go template file with the given data.
-// The template has access to the "env" function (wrapping os.Getenv) and uses "missingkey=error".
+// The template has access to the "env" function (wrapping os.Getenv), the
+// "dns1123" function (normalizing a string into a valid label value), and uses
+// "missingkey=error".
 func RenderTemplate(filename string, data any) ([]byte, error) {
 	//nolint:gosec // loading arbitrary template files is by design
 	content, err := os.ReadFile(filename)
@@ -148,7 +168,10 @@ func RenderTemplate(filename string, data any) ([]byte, error) {
 		return nil, err
 	}
 
-	tmpl, err := template.New(filepath.Base(filename)).Funcs(template.FuncMap{"env": os.Getenv}).Option("missingkey=error").Parse(string(content))
+	tmpl, err := template.New(filepath.Base(filename)).Funcs(template.FuncMap{
+		"env":     os.Getenv,
+		"dns1123": dns1123Label,
+	}).Option("missingkey=error").Parse(string(content))
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse template %s: %w", filename, err)
 	}


### PR DESCRIPTION
## What

Add a `dns1123` template function (alongside the existing `env`) that normalizes a string into a valid Kubernetes label value (RFC 1123): disallowed characters are replaced with `-`, the result is truncated to 63 characters, and leading/trailing non-alphanumeric characters are trimmed.

## Why

Patches that template values such as git refs into `machine.nodeLabels` can produce configs Talos rejects. For example:

```yaml
machine:
  nodeLabels:
    topf.postfinance.ch/config-revision: {{ .Data.configSource.ref }}
```

with `ref: feat/xyz` fails apply:

```
invalid machine node labels: label value "feat/xyz" is invalid
```

`RenderTemplate` only exposes `env`, so there is no in-template way to sanitize an arbitrary string. With this change:

```yaml
    topf.postfinance.ch/config-revision: {{ dns1123 .Data.configSource.ref }}
```

renders `feat-xyz`.

## Notes

- No new dependencies — uses the already-imported `regexp`.
- Tests cover slash refs, dotted versions, edge trimming, 63-char truncation, and empty input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)