### PR TITLE
docs: fixed typo 'you cluster' to 'your cluster' in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ docker pull ghcr.io/postfinance/topf
 
 Boot at least one Talos machine to maintenance mode.
 
-Create a new folder for you cluster with a `topf.yaml` file:
+Create a new folder for your cluster with a `topf.yaml` file:
 
 ```yaml
 kubernetesVersion: 1.35.3

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -45,7 +45,7 @@ These are only needed if your configuration uses SOPS encryption or vals referen
 
 Boot at least one Talos machine to maintenance mode.
 
-Create a new folder for you cluster with a `topf.yaml` file:
+Create a new folder for your cluster with a `topf.yaml` file:
 
 ```yaml
 kubernetesVersion: 1.34.1


### PR DESCRIPTION
just a small 2ch typo fix in README.md and docs/getting-started.md.

thanks for the tool