### PR TITLE
docs: extract mkdocs deps to requirements.txt and validate build on PRs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           python-version: "3.x"
 
-      - run: pip install mkdocs-material mdx-truly-sane-lists mike
+      - run: pip install -r docs/requirements.txt
 
       - name: Configure git
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,6 +2,11 @@ name: docs
 on:
   push:
     branches: [main]
+  pull_request:
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - ".github/workflows/docs.yml"
 
 permissions:
   contents: write
@@ -20,10 +25,15 @@ jobs:
 
       - run: pip install -r docs/requirements.txt
 
+      - name: Build docs (validation)
+        run: mkdocs build --strict
+
       - name: Configure git
+        if: github.ref == 'refs/heads/main'
         run: |
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
 
       - name: Deploy main docs
+        if: github.ref == 'refs/heads/main'
         run: mike deploy --push --update-aliases main

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -42,6 +42,11 @@ tasks:
     cmds:
       - git-cliff -o CHANGELOG.md
 
+  docs:install:
+    desc: Install documentation dependencies
+    cmds:
+      - pip install -r docs/requirements.txt
+
   docs:
     desc: Serve documentation locally
     cmds:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+mkdocs-material
+mdx-truly-sane-lists
+mike

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,8 @@ theme:
   name: material
   logo: assets/topf.png
   favicon: assets/topf.png
+  features:
+    - content.code.copy
   palette:
     - media: "(prefers-color-scheme: light)"
       scheme: default


### PR DESCRIPTION
The documentation dependencies (`mkdocs-material`, `mdx-truly-sane-lists`, `mike`) were hardcoded in the `docs.yml` workflow, with nothing to install them locally. This PR moves them into `docs/requirements.txt` and points the workflow at it, so CI and local setups share a single source of truth.

It also adds a `pull_request` trigger filtered on `docs/**`, `mkdocs.yml` and the workflow, along with a `mkdocs build --strict` step, so a broken docs build gets caught at PR time rather than after merge. The `mike deploy` steps now sit behind `if: github.ref == 'refs/heads/main'`, which keeps deployment on `main` while letting PRs run the build without publishing anything.

Finally, it enables `content.code.copy` in `mkdocs.yml`. The code blocks had no copy button, which made commands awkward to select by hand and prone to picking up stray characters.