### PR TITLE
feat: add 'staged' upgrade flag with optional label/taint

### DIFF
--- a/cmd/topf/upgrade.go
+++ b/cmd/topf/upgrade.go
@@ -70,7 +70,7 @@ func newUpgradeCmd() *cli.Command {
 			},
 			&cli.BoolFlag{
 				Name:    "stage",
-				Usage:   "install upgrade artifacts without rebooting; the node is labeled and/or tainted (see --stage-label/--stage-taint) so an external controller or human can reboot it later",
+				Usage:   "install upgrade artifacts without rebooting; the node can be rebooted later to complete the upgrade (Talos >= 1.13 only)",
 				Value:   false,
 				Sources: cli.EnvVars("TOPF_STAGE"),
 			},

--- a/cmd/topf/upgrade.go
+++ b/cmd/topf/upgrade.go
@@ -86,7 +86,7 @@ func newUpgradeCmd() *cli.Command {
 			},
 			&cli.StringSliceFlag{
 				Name:    "stage-taint",
-				Usage:   "Kubernetes node taint to apply after staging an upgrade (key=value:Effect); can be repeated; requires --stage",
+				Usage:   "Kubernetes node taint to apply after staging an upgrade (key[=value]:Effect); can be repeated; requires --stage",
 				Sources: cli.EnvVars("TOPF_STAGE_TAINT"),
 			},
 		},

--- a/cmd/topf/upgrade.go
+++ b/cmd/topf/upgrade.go
@@ -80,6 +80,11 @@ func newUpgradeCmd() *cli.Command {
 				Sources: cli.EnvVars("TOPF_STAGE_LABEL"),
 			},
 			&cli.StringSliceFlag{
+				Name:    "stage-annotation",
+				Usage:   "Kubernetes node annotation to apply after staging an upgrade (key=value); can be repeated; requires --stage",
+				Sources: cli.EnvVars("TOPF_STAGE_ANNOTATION"),
+			},
+			&cli.StringSliceFlag{
 				Name:    "stage-taint",
 				Usage:   "Kubernetes node taint to apply after staging an upgrade (key=value:Effect); can be repeated; requires --stage",
 				Sources: cli.EnvVars("TOPF_STAGE_TAINT"),
@@ -108,6 +113,7 @@ func newUpgradeCmd() *cli.Command {
 				DeleteIfEvictionFails: c.Bool("delete-if-eviction-fails"),
 				Stage:                 c.Bool("stage"),
 				StageLabels:           c.StringSlice("stage-label"),
+				StageAnnotations:      c.StringSlice("stage-annotation"),
 				StageTaints:           c.StringSlice("stage-taint"),
 				MaxParallel:           maxParallel,
 			})

--- a/cmd/topf/upgrade.go
+++ b/cmd/topf/upgrade.go
@@ -68,6 +68,22 @@ func newUpgradeCmd() *cli.Command {
 				Value:   false,
 				Sources: cli.EnvVars("TOPF_FORCE"),
 			},
+			&cli.BoolFlag{
+				Name:    "stage",
+				Usage:   "install upgrade artifacts without rebooting; the node is labeled and/or tainted (see --stage-label/--stage-taint) so an external controller or human can reboot it later",
+				Value:   false,
+				Sources: cli.EnvVars("TOPF_STAGE"),
+			},
+			&cli.StringSliceFlag{
+				Name:    "stage-label",
+				Usage:   "Kubernetes node label to apply after staging an upgrade (key=value); can be repeated; requires --stage",
+				Sources: cli.EnvVars("TOPF_STAGE_LABEL"),
+			},
+			&cli.StringSliceFlag{
+				Name:    "stage-taint",
+				Usage:   "Kubernetes node taint to apply after staging an upgrade (key=value:Effect); can be repeated; requires --stage",
+				Sources: cli.EnvVars("TOPF_STAGE_TAINT"),
+			},
 		},
 		Before: noPositionalArgs,
 		Action: func(ctx context.Context, c *cli.Command) error {
@@ -90,6 +106,9 @@ func newUpgradeCmd() *cli.Command {
 				Drain:                 c.Bool("drain"),
 				DrainTimeout:          c.Duration("drain-timeout"),
 				DeleteIfEvictionFails: c.Bool("delete-if-eviction-fails"),
+				Stage:                 c.Bool("stage"),
+				StageLabels:           c.StringSlice("stage-label"),
+				StageTaints:           c.StringSlice("stage-taint"),
 				MaxParallel:           maxParallel,
 			})
 			if errors.Is(err, topf.ErrDryRunChangesDetected) {

--- a/docs/commands/upgrade.md
+++ b/docs/commands/upgrade.md
@@ -70,7 +70,7 @@ All flags can also be set via environment variables using the `TOPF_` prefix and
 
 **Modern flow** *(Talos >= 1.13)*:
 
-1. Resolve the Kubernetes node name (if `--drain` is enabled, or if `--stage` with labels/taints)
+1. Resolve the Kubernetes node name (if `--drain` is enabled or for staged upgrades with `--stage-label` and/or `--stage-taint` and/or `--stage-annotation`)
 2. Pre-pull the installer image via `ImageService.Pull`
 3. Install the upgrade artifacts via `LifecycleService.Upgrade`
 4. **If `--stage` is set**: apply labels/annotations/taints (if any) and stop here — the node is not rebooted
@@ -157,7 +157,7 @@ topf upgrade --delete-if-eviction-fails --drain-timeout=10m
 topf upgrade --stage
 
 # Stage an upgrade and label the node so a controller can find it
-topf upgrade --stage --stage-label topf.io/staged-upgrade=true
+topf upgrade --stage --stage-label topf.postfinance.ch/staged-upgrade=true
 
 # Stage an upgrade and taint the node to discourage new pods from scheduling
 topf upgrade --stage --stage-taint topf.postfinance.ch/staged-upgrade=true:PreferNoSchedule

--- a/docs/commands/upgrade.md
+++ b/docs/commands/upgrade.md
@@ -44,19 +44,18 @@ All flags can also be set via environment variables using the `TOPF_` prefix and
 > direct deletion for the fallback attempt, which is what lets it bypass
 > PDBs.
 >
-> **Staging upgrades with `--stage`.** Sometimes you want to install new
-> Talos artifacts on nodes without immediately rebooting them — e.g. to
-> spread reboots over a maintenance window or let an external controller
-> (such as a drain scheduler) reboot nodes one at a time. `--stage`
-> installs the upgrade artifacts but skips the drain, reboot, and
-> uncordon steps. The node continues running on its current kernel until
-> it is manually rebooted, at which point the staged upgrade takes
-> effect.
+> **Staging upgrades with `--stage`** *(Talos >= 1.13 only)*. Sometimes you
+> want to install new Talos artifacts on nodes without immediately rebooting
+> them — e.g. to spread reboots over a maintenance window or let an external
+> controller (such as a drain scheduler) reboot nodes one at a time. `--stage`
+> installs the upgrade artifacts but skips the drain, reboot, and uncordon
+> steps. The node continues running on its current kernel until it is manually
+> rebooted, at which point the staged upgrade takes effect.
 >
-> `--stage-label` and `--stage-taint` mark the Kubernetes node so
-> controllers or humans can identify nodes with a pending reboot. For
-> example, `--stage-taint node-postfinance.ch/staged-upgrade=true:NoSchedule`
-> prevents new pods from scheduling on the node until it is rebooted and
+> `--stage-label` and `--stage-taint` mark the Kubernetes node so controllers
+> or humans can identify nodes with a pending reboot. For example,
+> `--stage-taint topf.postfinance.ch/staged-upgrade=true:PreferNoSchedule`
+> discourages new pods from scheduling on the node until it is rebooted and
 > the taint is removed. Both flags can be repeated and require `--stage`.
 > `--stage` is incompatible with `--drain` and `--delete-if-eviction-fails`.
 
@@ -158,6 +157,6 @@ topf upgrade --stage
 # Stage an upgrade and label the node so a controller can find it
 topf upgrade --stage --stage-label topf.io/staged-upgrade=true
 
-# Stage an upgrade and taint the node to prevent new pods from scheduling
-topf upgrade --stage --stage-taint node-postfinance.ch/staged-upgrade=true:NoSchedule
+# Stage an upgrade and taint the node to discourage new pods from scheduling
+topf upgrade --stage --stage-taint topf.postfinance.ch/staged-upgrade=true:PreferNoSchedule
 ```

--- a/docs/commands/upgrade.md
+++ b/docs/commands/upgrade.md
@@ -15,8 +15,9 @@ All flags can also be set via environment variables using the `TOPF_` prefix and
 | `--drain-timeout` | `5m` | Maximum time to wait for pod evictions (and, with `--delete-if-eviction-fails`, deletions) to complete during drain *(modern flow only)* |
 | `--delete-if-eviction-fails` | `false` | If graceful drain fails (e.g. a PodDisruptionBudget blocks eviction), retry by deleting pods directly (DELETE instead of EVICT, bypassing PDBs); reuses `--drain-timeout` for the delete fallback *(modern flow only)* |
 | `--force` | `false` | Skip etcd health checks; only applies to nodes running Talos < 1.13 (legacy `MachineService.Upgrade` RPC); has no effect on Talos >= 1.13, where the `LifecycleService.Upgrade` RPC validates etcd health server-side |
-| `--stage` | `false` | Install upgrade artifacts without rebooting; the node is left running and can be labeled/tainted (see `--stage-label`/`--stage-taint`) so an external controller or human reboots it later |
+| `--stage` | `false` | Install upgrade artifacts without rebooting; the node is left running and can be labeled/annotated/tainted (see `--stage-label`/`--stage-annotation`/`--stage-taint`) so an external controller or human reboots it later |
 | `--stage-label` | - | Kubernetes node label to apply after staging (`key=value`); can be repeated; requires `--stage` |
+| `--stage-annotation` | - | Kubernetes node annotation to apply after staging (`key=value`); can be repeated; requires `--stage` |
 | `--stage-taint` | - | Kubernetes node taint to apply after staging (`key=value:Effect`); can be repeated; requires `--stage` |
 | [`--nodes-filter`](../configuration.md#filtering-nodes) | - | Regex pattern to filter which nodes to operate on (global flag) |
 
@@ -52,11 +53,12 @@ All flags can also be set via environment variables using the `TOPF_` prefix and
 > steps. The node continues running on its current kernel until it is manually
 > rebooted, at which point the staged upgrade takes effect.
 >
-> `--stage-label` and `--stage-taint` mark the Kubernetes node so controllers
-> or humans can identify nodes with a pending reboot. For example,
+> `--stage-label`, `--stage-annotation`, and `--stage-taint` mark the
+> Kubernetes node so controllers or humans can identify nodes with a pending
+> reboot. For example,
 > `--stage-taint topf.postfinance.ch/staged-upgrade=true:PreferNoSchedule`
 > discourages new pods from scheduling on the node until it is rebooted and
-> the taint is removed. Both flags can be repeated and require `--stage`.
+> the taint is removed. All three flags can be repeated and require `--stage`.
 > `--stage` is incompatible with `--drain` and `--delete-if-eviction-fails`.
 
 ## Behavior
@@ -71,7 +73,7 @@ All flags can also be set via environment variables using the `TOPF_` prefix and
 1. Resolve the Kubernetes node name (if `--drain` is enabled, or if `--stage` with labels/taints)
 2. Pre-pull the installer image via `ImageService.Pull`
 3. Install the upgrade artifacts via `LifecycleService.Upgrade`
-4. **If `--stage` is set**: apply labels/taints (if any) and stop here — the node is not rebooted
+4. **If `--stage` is set**: apply labels/annotations/taints (if any) and stop here — the node is not rebooted
 5. Cordon and drain the Kubernetes node if `--drain` is enabled. **If the drain fails** (e.g. a pod cannot be evicted within `--drain-timeout`), the upgrade aborts unless `--delete-if-eviction-fails` is set: in that case, the drain retries with pod deletion (DELETE instead of EVICT, bypassing PodDisruptionBudgets, reusing `--drain-timeout`). If the forced drain also fails, the node is left cordoned with the new artifacts installed but not rebooted, and no further nodes are upgraded. In-flight upgrades on other nodes (when `--max-parallel > 1`) are allowed to complete, but no new ones are started. The node must be uncordoned and rebooted manually to recover.
 6. Issue a `Reboot` with the selected reboot mode (default: kexec)
 7. Wait 30 seconds for the node to stabilize
@@ -159,4 +161,7 @@ topf upgrade --stage --stage-label topf.io/staged-upgrade=true
 
 # Stage an upgrade and taint the node to discourage new pods from scheduling
 topf upgrade --stage --stage-taint topf.postfinance.ch/staged-upgrade=true:PreferNoSchedule
+
+# Stage an upgrade and annotate the node so a controller can find it
+topf upgrade --stage --stage-annotation topf.postfinance.ch/staged-at=2026-08-07
 ```

--- a/docs/commands/upgrade.md
+++ b/docs/commands/upgrade.md
@@ -59,7 +59,9 @@ All flags can also be set via environment variables using the `TOPF_` prefix and
 > `--stage-taint topf.postfinance.ch/staged-upgrade=true:PreferNoSchedule`
 > discourages new pods from scheduling on the node until it is rebooted and
 > the taint is removed. All three flags can be repeated and require `--stage`.
-> `--stage` is incompatible with `--drain` and `--delete-if-eviction-fails`.
+> `--stage` takes precedence over `--drain` and `--delete-if-eviction-fails`;
+> both are silently ignored when staging. No need to pass `--drain=false`
+> with `--stage`.
 
 ## Behavior
 

--- a/docs/commands/upgrade.md
+++ b/docs/commands/upgrade.md
@@ -15,6 +15,9 @@ All flags can also be set via environment variables using the `TOPF_` prefix and
 | `--drain-timeout` | `5m` | Maximum time to wait for pod evictions (and, with `--delete-if-eviction-fails`, deletions) to complete during drain *(modern flow only)* |
 | `--delete-if-eviction-fails` | `false` | If graceful drain fails (e.g. a PodDisruptionBudget blocks eviction), retry by deleting pods directly (DELETE instead of EVICT, bypassing PDBs); reuses `--drain-timeout` for the delete fallback *(modern flow only)* |
 | `--force` | `false` | Skip etcd health checks; only applies to nodes running Talos < 1.13 (legacy `MachineService.Upgrade` RPC); has no effect on Talos >= 1.13, where the `LifecycleService.Upgrade` RPC validates etcd health server-side |
+| `--stage` | `false` | Install upgrade artifacts without rebooting; the node is left running and can be labeled/tainted (see `--stage-label`/`--stage-taint`) so an external controller or human reboots it later |
+| `--stage-label` | - | Kubernetes node label to apply after staging (`key=value`); can be repeated; requires `--stage` |
+| `--stage-taint` | - | Kubernetes node taint to apply after staging (`key=value:Effect`); can be repeated; requires `--stage` |
 | [`--nodes-filter`](../configuration.md#filtering-nodes) | - | Regex pattern to filter which nodes to operate on (global flag) |
 
 > **Upgrade API selection.** Nodes running Talos >= 1.13 use the modern
@@ -40,6 +43,22 @@ All flags can also be set via environment variables using the `TOPF_` prefix and
 > `--delete-if-eviction-fails`. The flag only switches the eviction API to
 > direct deletion for the fallback attempt, which is what lets it bypass
 > PDBs.
+>
+> **Staging upgrades with `--stage`.** Sometimes you want to install new
+> Talos artifacts on nodes without immediately rebooting them — e.g. to
+> spread reboots over a maintenance window or let an external controller
+> (such as a drain scheduler) reboot nodes one at a time. `--stage`
+> installs the upgrade artifacts but skips the drain, reboot, and
+> uncordon steps. The node continues running on its current kernel until
+> it is manually rebooted, at which point the staged upgrade takes
+> effect.
+>
+> `--stage-label` and `--stage-taint` mark the Kubernetes node so
+> controllers or humans can identify nodes with a pending reboot. For
+> example, `--stage-taint node-postfinance.ch/staged-upgrade=true:NoSchedule`
+> prevents new pods from scheduling on the node until it is rebooted and
+> the taint is removed. Both flags can be repeated and require `--stage`.
+> `--stage` is incompatible with `--drain` and `--delete-if-eviction-fails`.
 
 ## Behavior
 
@@ -50,17 +69,18 @@ All flags can also be set via environment variables using the `TOPF_` prefix and
 
 **Modern flow** *(Talos >= 1.13)*:
 
-1. Resolve the Kubernetes node name (if `--drain` is enabled)
+1. Resolve the Kubernetes node name (if `--drain` is enabled, or if `--stage` with labels/taints)
 2. Pre-pull the installer image via `ImageService.Pull`
 3. Install the upgrade artifacts via `LifecycleService.Upgrade`
-4. Cordon and drain the Kubernetes node if `--drain` is enabled. **If the drain fails** (e.g. a pod cannot be evicted within `--drain-timeout`), the upgrade aborts unless `--delete-if-eviction-fails` is set: in that case, the drain retries with pod deletion (DELETE instead of EVICT, bypassing PodDisruptionBudgets, reusing `--drain-timeout`). If the forced drain also fails, the node is left cordoned with the new artifacts installed but not rebooted, and no further nodes are upgraded. In-flight upgrades on other nodes (when `--max-parallel > 1`) are allowed to complete, but no new ones are started. The node must be uncordoned and rebooted manually to recover.
-5. Issue a `Reboot` with the selected reboot mode (default: kexec)
-6. Wait 30 seconds for the node to stabilize
-7. Uncordon the Kubernetes node
+4. **If `--stage` is set**: apply labels/taints (if any) and stop here — the node is not rebooted
+5. Cordon and drain the Kubernetes node if `--drain` is enabled. **If the drain fails** (e.g. a pod cannot be evicted within `--drain-timeout`), the upgrade aborts unless `--delete-if-eviction-fails` is set: in that case, the drain retries with pod deletion (DELETE instead of EVICT, bypassing PodDisruptionBudgets, reusing `--drain-timeout`). If the forced drain also fails, the node is left cordoned with the new artifacts installed but not rebooted, and no further nodes are upgraded. In-flight upgrades on other nodes (when `--max-parallel > 1`) are allowed to complete, but no new ones are started. The node must be uncordoned and rebooted manually to recover.
+6. Issue a `Reboot` with the selected reboot mode (default: kexec)
+7. Wait 30 seconds for the node to stabilize
+8. Uncordon the Kubernetes node
 
 **Legacy flow** *(Talos < 1.13)*:
 
-1. Issue `MachineService.Upgrade`, which installs the upgrade artifacts, cordons and drains the node, and reboots — all in a single server-side sequence. `--drain` and `--drain-timeout` are ignored (Talos drains and uncordons the node itself); `--force` skips etcd health checks.
+1. Issue `MachineService.Upgrade`, which installs the upgrade artifacts, cordons and drains the node, and reboots — all in a single server-side sequence. `--drain` and `--drain-timeout` are ignored (Talos drains and uncordons the node itself); `--force` skips etcd health checks. `--stage` is not supported on legacy nodes.
 2. Wait 30 seconds for the node to stabilize
 
 ## Installer Image
@@ -131,4 +151,13 @@ topf upgrade --delete-if-eviction-fails
 
 # Upgrade with a longer drain timeout (shared by graceful and fallback)
 topf upgrade --delete-if-eviction-fails --drain-timeout=10m
+
+# Stage an upgrade without rebooting (reboot manually later to complete it)
+topf upgrade --stage
+
+# Stage an upgrade and label the node so a controller can find it
+topf upgrade --stage --stage-label topf.io/staged-upgrade=true
+
+# Stage an upgrade and taint the node to prevent new pods from scheduling
+topf upgrade --stage --stage-taint node-postfinance.ch/staged-upgrade=true:NoSchedule
 ```

--- a/internal/cmd/upgrade/upgrade.go
+++ b/internal/cmd/upgrade/upgrade.go
@@ -187,8 +187,12 @@ func validateOptions(opts *Options) error {
 			return fmt.Errorf("invalid taint %q: expected key[=value]:Effect", tw)
 		}
 
-		k, v, ok := strings.Cut(kv, "=")
-		if !ok || k == "" {
+		k, v := kv, ""
+		if before, after, ok := strings.Cut(kv, "="); ok {
+			k, v = before, after
+		}
+
+		if k == "" {
 			return fmt.Errorf("invalid taint %q: expected key[=value]:Effect", tw)
 		}
 

--- a/internal/cmd/upgrade/upgrade.go
+++ b/internal/cmd/upgrade/upgrade.go
@@ -256,6 +256,11 @@ func plan(t topf.Topf, logger *slog.Logger, nodes []*topf.Node, opts Options) (w
 
 		upgradeRequired = true
 
+		// --stage is only supported on Talos >= 1.13 (LifecycleService flow).
+		if opts.Stage && !supportsLifecycleUpgrade(node.RunningVersion()) {
+			return nil, false, fmt.Errorf("node %s runs Talos %s: --stage requires Talos >= 1.13", node.Node.Host, node.RunningVersion())
+		}
+
 		// in dry-run mode, skip the actual upgrade
 		if opts.DryRun {
 			continue

--- a/internal/cmd/upgrade/upgrade.go
+++ b/internal/cmd/upgrade/upgrade.go
@@ -572,7 +572,7 @@ func drainPods(ctx context.Context, clientset kubernetes.Interface, nodeName str
 }
 
 func hasStagePatch(p corev1.Node) bool {
-	return len(p.Labels) > 0 || len(p.Spec.Taints) > 0
+	return len(p.Labels) > 0 || len(p.Annotations) > 0 || len(p.Spec.Taints) > 0
 }
 
 func applyStagePatch(ctx context.Context, t topf.Topf, nodeName string, patch corev1.Node, logger *slog.Logger) error {

--- a/internal/cmd/upgrade/upgrade.go
+++ b/internal/cmd/upgrade/upgrade.go
@@ -663,7 +663,7 @@ func runUpgrade(ctx context.Context, c *client.Client, containerdInstance *commo
 
 		switch p := progress.GetResponse().(type) {
 		case *machine.LifecycleServiceInstallProgress_Message:
-			logger.Info("upgrade progress", "message", p.Message)
+			logger.Debug("upgrade progress", "message", p.Message)
 		case *machine.LifecycleServiceInstallProgress_ExitCode:
 			if p.ExitCode != 0 {
 				return fmt.Errorf("upgrade failed with exit code %d", p.ExitCode)

--- a/internal/cmd/upgrade/upgrade.go
+++ b/internal/cmd/upgrade/upgrade.go
@@ -192,7 +192,7 @@ func validateOptions(opts *Options) error {
 
 		k, v, ok := strings.Cut(kv, "=")
 		if !ok || k == "" {
-			return fmt.Errorf("invalid taint %q: expected key=value:Effect", tw)
+			return fmt.Errorf("invalid taint %q: expected key[=value]:Effect", tw)
 		}
 
 		stagePatch.Spec.Taints = append(stagePatch.Spec.Taints, corev1.Taint{

--- a/internal/cmd/upgrade/upgrade.go
+++ b/internal/cmd/upgrade/upgrade.go
@@ -70,12 +70,16 @@ type Options struct {
 	// staging. Requires Stage.
 	StageLabels []string
 
+	// StageAnnotations are Kubernetes node annotations (key=value) applied
+	// after staging. Requires Stage.
+	StageAnnotations []string
+
 	// StageTaints are Kubernetes node taints (key=value:Effect) applied
 	// after staging. Requires Stage.
 	StageTaints []string
 
-	// stagePatch is the pre-parsed node patch (labels + taints), built
-	// once in validateOptions. Zero-valued if no labels/taints are set.
+	// stagePatch is the pre-parsed node patch (labels + annotations + taints), built
+	// once in validateOptions. Zero-valued if no labels/annotations/taints are set.
 	stagePatch corev1.Node
 
 	// MaxParallel controls how many worker nodes are upgraded concurrently.
@@ -141,14 +145,14 @@ func Execute(ctx context.Context, t topf.Topf, opts Options) error {
 
 func validateOptions(opts *Options) error {
 	if !opts.Stage {
-		if len(opts.StageLabels) > 0 || len(opts.StageTaints) > 0 {
-			return errors.New("--stage-label and --stage-taint require --stage")
+		if len(opts.StageLabels) > 0 || len(opts.StageAnnotations) > 0 || len(opts.StageTaints) > 0 {
+			return errors.New("--stage-label, --stage-annotation, and --stage-taint require --stage")
 		}
 
 		return nil
 	}
 
-	if len(opts.StageLabels) == 0 && len(opts.StageTaints) == 0 {
+	if len(opts.StageLabels) == 0 && len(opts.StageAnnotations) == 0 && len(opts.StageTaints) == 0 {
 		return nil
 	}
 
@@ -165,6 +169,19 @@ func validateOptions(opts *Options) error {
 		}
 
 		stagePatch.Labels[k] = v
+	}
+
+	for _, a := range opts.StageAnnotations {
+		k, v, ok := strings.Cut(a, "=")
+		if !ok || k == "" {
+			return fmt.Errorf("invalid annotation %q: expected key=value", a)
+		}
+
+		if stagePatch.Annotations == nil {
+			stagePatch.Annotations = map[string]string{}
+		}
+
+		stagePatch.Annotations[k] = v
 	}
 
 	for _, tw := range opts.StageTaints {

--- a/internal/cmd/upgrade/upgrade.go
+++ b/internal/cmd/upgrade/upgrade.go
@@ -6,12 +6,14 @@ package upgrade
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"log/slog"
 	"regexp"
 	"slices"
+	"strings"
 	"sync"
 	"time"
 
@@ -28,6 +30,7 @@ import (
 	"google.golang.org/grpc/codes"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/kubectl/pkg/drain"
 
@@ -59,6 +62,23 @@ type Options struct {
 	// (DELETE instead of EVICT, bypassing PDBs) if the graceful drain fails.
 	DeleteIfEvictionFails bool
 
+	// Stage installs upgrade artifacts without rebooting. The node is
+	// labeled/tainted (if StageLabels/StageTaints are set) so an external
+	// controller or human can reboot it later.
+	Stage bool
+
+	// StageLabels are Kubernetes node labels (key=value) applied after
+	// staging. Requires Stage.
+	StageLabels []string
+
+	// StageTaints are Kubernetes node taints (key=value:Effect) applied
+	// after staging. Requires Stage.
+	StageTaints []string
+
+	// stagePatch is the pre-parsed node patch (labels + taints), built
+	// once in validateOptions. Zero-valued if no labels/taints are set.
+	stagePatch corev1.Node
+
 	// MaxParallel controls how many worker nodes are upgraded concurrently.
 	// Control-plane nodes are always upgraded one at a time.
 	MaxParallel nodepool.MaxParallel
@@ -67,6 +87,10 @@ type Options struct {
 // Execute performs the Talos OS upgrades for all nodes in the cluster
 func Execute(ctx context.Context, t topf.Topf, opts Options) error {
 	logger := t.Logger().With("command", "upgrade")
+
+	if err := validateOptions(&opts); err != nil {
+		return err
+	}
 
 	// Gather node information
 	nodes, err := t.FilteredNodes(ctx)
@@ -115,6 +139,59 @@ func Execute(ctx context.Context, t topf.Topf, opts Options) error {
 				return upgradeNode(ctx, t, node, opts, logger)
 			}, logger)
 	}
+
+	return nil
+}
+
+// validateOptions checks for incompatible flag combinations and pre-parses
+// the staging labels/taints into a strategic merge patch stored on opts.
+func validateOptions(opts *Options) error {
+	if !opts.Stage {
+		if len(opts.StageLabels) > 0 || len(opts.StageTaints) > 0 {
+			return errors.New("--stage-label and --stage-taint require --stage")
+		}
+
+		return nil
+	}
+
+	if len(opts.StageLabels) == 0 && len(opts.StageTaints) == 0 {
+		return nil
+	}
+
+	stagePatch := corev1.Node{}
+
+	for _, l := range opts.StageLabels {
+		k, v, ok := strings.Cut(l, "=")
+		if !ok || k == "" {
+			return fmt.Errorf("invalid label %q: expected key=value", l)
+		}
+
+		if stagePatch.Labels == nil {
+			stagePatch.Labels = map[string]string{}
+		}
+
+		stagePatch.Labels[k] = v
+	}
+
+	for _, tw := range opts.StageTaints {
+		kv, effect, ok := strings.Cut(tw, ":")
+		if !ok || effect == "" {
+			return fmt.Errorf("invalid taint %q: expected key=value:Effect", tw)
+		}
+
+		k, v, ok := strings.Cut(kv, "=")
+		if !ok || k == "" {
+			return fmt.Errorf("invalid taint %q: expected key=value:Effect", tw)
+		}
+
+		stagePatch.Spec.Taints = append(stagePatch.Spec.Taints, corev1.Taint{
+			Key:    k,
+			Value:  v,
+			Effect: corev1.TaintEffect(effect),
+		})
+	}
+
+	opts.stagePatch = stagePatch
 
 	return nil
 }
@@ -184,9 +261,11 @@ func plan(t topf.Topf, logger *slog.Logger, nodes []*topf.Node, opts Options) (w
 			continue
 		}
 
-		// ask for user confirmation
-		if t.Confirm() {
-			if interactive.ConfirmPrompt(fmt.Sprintf("Do you want to upgrade node %s with installer %s? This will reboot the node.", node.Node.Host, installerImage)) == 'n' {
+		// ask for user confirmation (staging is non-disruptive — no reboot)
+		if t.Confirm() && !opts.Stage {
+			prompt := fmt.Sprintf("Do you want to upgrade node %s with installer %s? This will reboot the node.", node.Node.Host, installerImage)
+
+			if interactive.ConfirmPrompt(prompt) == 'n' {
 				logger.Info("skipping upgrade")
 				continue
 			}
@@ -279,9 +358,10 @@ func upgradeNodeLifecycle(ctx context.Context, t topf.Topf, node *topf.Node, opt
 
 	// Resolve the Kubernetes node name up front, so that a drain failure
 	// can't be caused by a reason that was knowable before the upgrade.
+	// Staging also needs it if labels or taints are to be applied.
 	k8sNodeName := ""
 
-	if opts.Drain {
+	if opts.Drain || (opts.Stage && hasStagePatch(opts.stagePatch)) {
 		k8sNodeName, err = talosnodedrain.GetKubernetesNodeName(ctx, nodeClient)
 		if err != nil {
 			return fmt.Errorf("resolving kubernetes node name: %w", err)
@@ -296,6 +376,21 @@ func upgradeNodeLifecycle(ctx context.Context, t topf.Topf, node *topf.Node, opt
 
 	if err := runUpgrade(ctx, nodeClient, containerdInstance, installerImage, logger); err != nil {
 		return fmt.Errorf("upgrade: %w", err)
+	}
+
+	// Staging: artifacts are installed, skip drain/reboot. Optionally
+	// label and/or taint the Kubernetes node so an external controller or
+	// human knows which nodes have a pending upgrade.
+	if opts.Stage {
+		if hasStagePatch(opts.stagePatch) {
+			if err := applyStagePatch(ctx, t, k8sNodeName, opts.stagePatch, logger); err != nil {
+				return err
+			}
+		}
+
+		logger.Info("upgrade staged; node not rebooted — reboot manually to complete the upgrade", "k8s_node", k8sNodeName)
+
+		return nil
 	}
 
 	// Drain the node after the upgrade artifacts are installed but before
@@ -362,6 +457,9 @@ func upgradeNodeLifecycle(ctx context.Context, t topf.Topf, node *topf.Node, opt
 //
 // The opts.Drain and opts.DrainTimeout flags are ignored on this path: Talos
 // drains and uncordons the node itself as part of the upgrade sequence.
+//
+// The opts.Stage flag is not supported on this path; staging is only available
+// on nodes running Talos >= 1.13 (modern LifecycleService.Upgrade flow).
 //
 // The provided logger is expected to already carry the node's attributes.
 //
@@ -555,6 +653,33 @@ func drainPods(ctx context.Context, clientset kubernetes.Interface, nodeName str
 
 	if err := drain.RunNodeDrain(drainer, nodeName); err != nil {
 		return fmt.Errorf("draining node %q: %w", nodeName, err)
+	}
+
+	return nil
+}
+
+// hasStagePatch reports whether the node patch has any labels or taints set.
+func hasStagePatch(p corev1.Node) bool {
+	return len(p.Labels) > 0 || len(p.Spec.Taints) > 0
+}
+
+// applyStagePatch applies the pre-parsed node patch (labels + taints) to the
+// Kubernetes node via a strategic merge patch after staging an upgrade.
+func applyStagePatch(ctx context.Context, t topf.Topf, nodeName string, patch corev1.Node, logger *slog.Logger) error {
+	clientset, err := newK8sClientset(ctx, t, logger)
+	if err != nil {
+		return fmt.Errorf("creating kubernetes client for staging: %w", err)
+	}
+
+	patchData, err := json.Marshal(patch)
+	if err != nil {
+		return fmt.Errorf("marshaling node patch: %w", err)
+	}
+
+	logger.Info("staging: applying node patch", "k8s_node", nodeName)
+
+	if _, err := clientset.CoreV1().Nodes().Patch(ctx, nodeName, types.StrategicMergePatchType, patchData, metav1.PatchOptions{}); err != nil {
+		return fmt.Errorf("patching node %q: %w", nodeName, err)
 	}
 
 	return nil

--- a/internal/cmd/upgrade/upgrade.go
+++ b/internal/cmd/upgrade/upgrade.go
@@ -27,7 +27,6 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/client"
 	"github.com/siderolabs/talos/pkg/machinery/resources/runtime"
 	"github.com/siderolabs/talos/pkg/reporter"
-	"google.golang.org/grpc/codes"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -92,7 +91,6 @@ func Execute(ctx context.Context, t topf.Topf, opts Options) error {
 		return err
 	}
 
-	// Gather node information
 	nodes, err := t.FilteredNodes(ctx)
 	if err != nil {
 		return err
@@ -128,8 +126,6 @@ func Execute(ctx context.Context, t topf.Topf, opts Options) error {
 		}
 	}
 
-	// Worker nodes are upgraded using a rolling pool: up to n upgrades are kept
-	// in flight, and as soon as one finishes the next node is started.
 	if len(workers) > 0 {
 		concurrency := opts.MaxParallel.Resolve(len(nodes))
 		logger.Info("upgrading worker nodes", "count", len(workers), "concurrency", concurrency)
@@ -143,8 +139,6 @@ func Execute(ctx context.Context, t topf.Topf, opts Options) error {
 	return nil
 }
 
-// validateOptions checks for incompatible flag combinations and pre-parses
-// the staging labels/taints into a strategic merge patch stored on opts.
 func validateOptions(opts *Options) error {
 	if !opts.Stage {
 		if len(opts.StageLabels) > 0 || len(opts.StageTaints) > 0 {
@@ -256,17 +250,14 @@ func plan(t topf.Topf, logger *slog.Logger, nodes []*topf.Node, opts Options) (w
 
 		upgradeRequired = true
 
-		// --stage is only supported on Talos >= 1.13 (LifecycleService flow).
 		if opts.Stage && !supportsLifecycleUpgrade(node.RunningVersion()) {
 			return nil, false, fmt.Errorf("node %s runs Talos %s: --stage requires Talos >= 1.13", node.Node.Host, node.RunningVersion())
 		}
 
-		// in dry-run mode, skip the actual upgrade
 		if opts.DryRun {
 			continue
 		}
 
-		// ask for user confirmation (staging is non-disruptive — no reboot)
 		if t.Confirm() && !opts.Stage {
 			prompt := fmt.Sprintf("Do you want to upgrade node %s with installer %s? This will reboot the node.", node.Node.Host, installerImage)
 
@@ -282,17 +273,6 @@ func plan(t topf.Topf, logger *slog.Logger, nodes []*topf.Node, opts Options) (w
 	return worklist, upgradeRequired, nil
 }
 
-// upgradeNode performs a Talos OS upgrade on a single node. It selects the
-// upgrade mechanism based on the node's running Talos version:
-//
-//   - Talos >= 1.13.0: LifecycleService.Upgrade streaming RPC (the modern
-//     flow), which installs artifacts, then a separate Reboot, with optional
-//     Kubernetes drain/uncordon around the reboot.
-//   - Talos < 1.13.0: legacy MachineService.Upgrade RPC (which installs
-//     and reboots in a single call). The LifecycleService.Upgrade RPC was
-//     introduced in v1.13.0 and returns codes.Unimplemented on older nodes.
-//
-// The provided logger is expected to already carry the node's attributes.
 func upgradeNode(ctx context.Context, t topf.Topf, node *topf.Node, opts Options, logger *slog.Logger) error {
 	if supportsLifecycleUpgrade(node.RunningVersion()) {
 		return upgradeNodeLifecycle(ctx, t, node, opts, logger)
@@ -303,10 +283,6 @@ func upgradeNode(ctx context.Context, t topf.Topf, node *topf.Node, opts Options
 	return upgradeNodeLegacy(ctx, t, node, opts, logger)
 }
 
-// supportsLifecycleUpgrade reports whether the node's running Talos version
-// supports the LifecycleService.Upgrade streaming RPC (introduced in v1.13.0).
-// A node whose running version is unknown is assumed to support it; the RPC
-// will surface codes.Unimplemented if it does not.
 func supportsLifecycleUpgrade(runningVersion string) bool {
 	if runningVersion == "" {
 		return true
@@ -320,38 +296,6 @@ func supportsLifecycleUpgrade(runningVersion string) bool {
 	return v.GTE(semver.MustParse("1.13.0"))
 }
 
-// upgradeNodeLifecycle performs a Talos OS upgrade on a single node using the
-// LifecycleService.Upgrade streaming RPC. The flow is:
-//
-//  1. Resolve the Kubernetes node name (if draining is enabled), so that
-//     a drain failure can't be caused by a reason that was knowable before
-//     the upgrade mutated the node.
-//  2. Pre-pull the installer image via ImageService.Pull.
-//  3. Stream LifecycleService.Upgrade, draining progress messages and
-//     verifying the final exit code is zero.
-//  4. Drain the Kubernetes node (cordon + evict pods) if draining is enabled.
-//     If the drain fails, the upgrade aborts: the node is left cordoned with
-//     the new artifacts installed but not rebooted. The error propagates to
-//     the caller (RunConcurrent), which stops scheduling new upgrades but
-//     lets in-flight ones finish. The node must be uncordoned and rebooted
-//     manually to recover.
-//  5. Issue a Reboot with the configured reboot mode. A gRPC Unavailable or
-//     Canceled error from Reboot is treated as success: the node begins
-//     shutting down before the RPC response reaches us.
-//  6. Close the per-node Talos client (the node is rebooting; the connection
-//     is dead anyway).
-//  7. Wait for the node to stabilize.
-//  8. Re-fetch a Kubernetes clientset and uncordon the node. The clientset
-//     is re-fetched (rather than reused from step 4) because the reboot may
-//     rotate credentials or invalidate the in-memory kubeconfig, and the
-//     control-plane node we proxy through may itself have been upgraded.
-//
-// The kubeconfig for drain/uncordon operations is fetched via a control-plane
-// node client (t.ControlPlaneClient), because the Kubeconfig RPC is only
-// available on control-plane nodes. GetKubernetesNodeName uses the node's own
-// client, as the Nodename resource is available on all nodes.
-//
-// The provided logger is expected to already carry the node's attributes.
 func upgradeNodeLifecycle(ctx context.Context, t topf.Topf, node *topf.Node, opts Options, logger *slog.Logger) error {
 	installerImage := node.ConfigProvider().Machine().Install().Image()
 
@@ -361,9 +305,6 @@ func upgradeNodeLifecycle(ctx context.Context, t topf.Topf, node *topf.Node, opt
 	}
 	defer nodeClient.Close()
 
-	// Resolve the Kubernetes node name up front, so that a drain failure
-	// can't be caused by a reason that was knowable before the upgrade.
-	// Staging also needs it if labels or taints are to be applied.
 	k8sNodeName := ""
 
 	if opts.Drain || (opts.Stage && hasStagePatch(opts.stagePatch)) {
@@ -383,9 +324,6 @@ func upgradeNodeLifecycle(ctx context.Context, t topf.Topf, node *topf.Node, opt
 		return fmt.Errorf("upgrade: %w", err)
 	}
 
-	// Staging: artifacts are installed, skip drain/reboot. Optionally
-	// label and/or taint the Kubernetes node so an external controller or
-	// human knows which nodes have a pending upgrade.
 	if opts.Stage {
 		if hasStagePatch(opts.stagePatch) {
 			if err := applyStagePatch(ctx, t, k8sNodeName, opts.stagePatch, logger); err != nil {
@@ -398,8 +336,6 @@ func upgradeNodeLifecycle(ctx context.Context, t topf.Topf, node *topf.Node, opt
 		return nil
 	}
 
-	// Drain the node after the upgrade artifacts are installed but before
-	// the reboot, so pods are evicted gracefully.
 	if opts.Drain {
 		if err := drainNode(ctx, t, opts, k8sNodeName, logger); err != nil {
 			return err
@@ -408,17 +344,10 @@ func upgradeNodeLifecycle(ctx context.Context, t topf.Topf, node *topf.Node, opt
 
 	logger.Info("upgrade artifacts installed, rebooting node", "reboot_mode", opts.RebootMode.String())
 
-	// Reboot returns once the reboot is initiated. If the node starts
-	// shutting down before the gRPC response arrives, the stream is torn
-	// down and we get Unavailable or Canceled. Both are expected here.
-	if err := nodeClient.Reboot(ctx, client.WithRebootMode(opts.RebootMode)); err != nil &&
-		client.StatusCode(err) != codes.Unavailable &&
-		!errors.Is(err, context.Canceled) {
+	if err := nodeClient.Reboot(ctx, client.WithRebootMode(opts.RebootMode)); err != nil {
 		return fmt.Errorf("reboot: %w", err)
 	}
 
-	// The node is rebooting; the per-node client is dead. Close it now
-	// rather than holding it open across the stabilization window.
 	if cerr := nodeClient.Close(); cerr != nil {
 		logger.Debug("closing per-node client after reboot", "error", cerr)
 	}
@@ -429,10 +358,6 @@ func upgradeNodeLifecycle(ctx context.Context, t topf.Topf, node *topf.Node, opt
 		return fmt.Errorf("node didn't stabilize: %w", err)
 	}
 
-	// After the node has stabilized, uncordon it so that the Kubernetes
-	// scheduler can place pods on it again. The clientset is re-fetched
-	// because the reboot may have rotated credentials or invalidated the
-	// in-memory kubeconfig obtained before the reboot.
 	if opts.Drain {
 		uncordonClientset, err := newK8sClientset(ctx, t, logger)
 		if err != nil {
@@ -453,21 +378,6 @@ func upgradeNodeLifecycle(ctx context.Context, t topf.Topf, node *topf.Node, opt
 	return nil
 }
 
-// upgradeNodeLegacy performs a Talos OS upgrade on a node running Talos < 1.13
-// using the deprecated MachineService.Upgrade RPC. Unlike the lifecycle flow,
-// this RPC installs the upgrade artifacts, drains the Kubernetes node, and
-// reboots in a single server-side sequence (see Talos's Upgrade sequencer).
-// The opts.Force flag skips etcd health checks on this path (the legacy RPC's
-// only safety knob).
-//
-// The opts.Drain and opts.DrainTimeout flags are ignored on this path: Talos
-// drains and uncordons the node itself as part of the upgrade sequence.
-//
-// The opts.Stage flag is not supported on this path; staging is only available
-// on nodes running Talos >= 1.13 (modern LifecycleService.Upgrade flow).
-//
-// The provided logger is expected to already carry the node's attributes.
-//
 //nolint:staticcheck // the non-deprecated replacement (LifecycleClient.Upgrade) requires Talos >= 1.13
 func upgradeNodeLegacy(ctx context.Context, _ topf.Topf, node *topf.Node, opts Options, logger *slog.Logger) error {
 	installerImage := node.ConfigProvider().Machine().Install().Image()
@@ -499,10 +409,6 @@ func upgradeNodeLegacy(ctx context.Context, _ topf.Topf, node *topf.Node, opts O
 	return nil
 }
 
-// toLegacyRebootMode maps the RebootRequest_Mode used by the lifecycle flow
-// to the UpgradeRequest_RebootMode consumed by the legacy
-// MachineService.Upgrade RPC. The enum values are identical, but the types
-// are distinct.
 func toLegacyRebootMode(mode machine.RebootRequest_Mode) machine.UpgradeRequest_RebootMode {
 	switch mode {
 	case machine.RebootRequest_POWERCYCLE:
@@ -512,10 +418,6 @@ func toLegacyRebootMode(mode machine.RebootRequest_Mode) machine.UpgradeRequest_
 	}
 }
 
-// newK8sClientset obtains an in-memory Kubernetes clientset by fetching the
-// admin kubeconfig through a control-plane node's Talos API. The control-plane
-// client is closed after the kubeconfig is retrieved; the returned clientset
-// is independent of it.
 func newK8sClientset(ctx context.Context, t topf.Topf, logger *slog.Logger) (kubernetes.Interface, error) {
 	cpClient, err := t.ControlPlaneClient(ctx)
 	if err != nil {
@@ -535,9 +437,6 @@ func newK8sClientset(ctx context.Context, t topf.Topf, logger *slog.Logger) (kub
 	return clientset, nil
 }
 
-// drainNode cordons the node, then drains its pods. If the graceful drain
-// fails and DeleteIfEvictionFails is set, retries with direct pod deletion
-// (bypassing PDBs). The node is cordoned once; the fallback does not re-cordon.
 func drainNode(ctx context.Context, t topf.Topf, opts Options, k8sNodeName string, logger *slog.Logger) error {
 	clientset, err := newK8sClientset(ctx, t, logger)
 	if err != nil {
@@ -576,7 +475,6 @@ func drainNode(ctx context.Context, t topf.Topf, opts Options, k8sNodeName strin
 	return nil
 }
 
-// cordonNode marks the Kubernetes node unschedulable.
 func cordonNode(ctx context.Context, clientset kubernetes.Interface, nodeName string, logger *slog.Logger) error {
 	node, err := clientset.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
 	if err != nil {
@@ -601,10 +499,6 @@ func cordonNode(ctx context.Context, clientset kubernetes.Interface, nodeName st
 	return nil
 }
 
-// drainPods drains the node's pods via the kubectl drain library. Force is
-// always on (unmanaged pods deleted, emptyDir data removed). When
-// deleteIfEvictionFails is true, pods are DELETEd instead of EVICTed, bypassing
-// PDBs (kubectl drain --disable-eviction).
 func drainPods(ctx context.Context, clientset kubernetes.Interface, nodeName string, timeout time.Duration, deleteIfEvictionFails bool, logger *slog.Logger) error {
 	drainCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
@@ -614,9 +508,6 @@ func drainPods(ctx context.Context, clientset kubernetes.Interface, nodeName str
 		action = "deleting"
 	}
 
-	// The drain helper fires the {Deletion,Eviction}Started callback on every
-	// retry attempt; we track announced pods in this map and report the outcome
-	// in Finished.
 	var announced sync.Map
 
 	drainer := &drain.Helper{
@@ -663,13 +554,10 @@ func drainPods(ctx context.Context, clientset kubernetes.Interface, nodeName str
 	return nil
 }
 
-// hasStagePatch reports whether the node patch has any labels or taints set.
 func hasStagePatch(p corev1.Node) bool {
 	return len(p.Labels) > 0 || len(p.Spec.Taints) > 0
 }
 
-// applyStagePatch applies the pre-parsed node patch (labels + taints) to the
-// Kubernetes node via a strategic merge patch after staging an upgrade.
 func applyStagePatch(ctx context.Context, t topf.Topf, nodeName string, patch corev1.Node, logger *slog.Logger) error {
 	clientset, err := newK8sClientset(ctx, t, logger)
 	if err != nil {
@@ -690,9 +578,6 @@ func applyStagePatch(ctx context.Context, t topf.Topf, nodeName string, patch co
 	return nil
 }
 
-// systemContainerdInstance returns the containerd instance used for pulling
-// and running installer artifacts: the CRI driver against the system
-// namespace. This matches talosctl's default for upgrades ("system").
 func systemContainerdInstance() *common.ContainerdInstance {
 	return &common.ContainerdInstance{
 		Driver:    common.ContainerDriver_CRI,
@@ -700,9 +585,6 @@ func systemContainerdInstance() *common.ContainerdInstance {
 	}
 }
 
-// pullInstallerImage pre-pulls the installer image via the
-// ImageService.Pull streaming RPC. Progress messages are logged at debug
-// level; the stream completes when the server sends the image name.
 func pullInstallerImage(ctx context.Context, c *client.Client, containerdInstance *common.ContainerdInstance, imageRef string, logger *slog.Logger) error {
 	stream, err := c.ImageClient.Pull(ctx, &machine.ImageServicePullRequest{
 		Containerd: containerdInstance,
@@ -728,7 +610,6 @@ func pullInstallerImage(ctx context.Context, c *client.Client, containerdInstanc
 				"layer", payload.PullProgress.GetLayerId(),
 				"progress", payload.PullProgress.GetProgress())
 		case *machine.ImageServicePullResponse_Name:
-			// final message: server reports the resolved image name
 			logger.Info("installer image pulled", "image", payload.Name)
 
 			return nil
@@ -736,9 +617,6 @@ func pullInstallerImage(ctx context.Context, c *client.Client, containerdInstanc
 	}
 }
 
-// runUpgrade invokes the LifecycleService.Upgrade streaming RPC and
-// drains progress messages until the server sends a terminal exit code. A
-// non-zero exit code is surfaced as an error.
 func runUpgrade(ctx context.Context, c *client.Client, containerdInstance *common.ContainerdInstance, imageRef string, logger *slog.Logger) error {
 	stream, err := c.LifecycleClient.Upgrade(ctx, &machine.LifecycleServiceUpgradeRequest{
 		Containerd: containerdInstance,

--- a/internal/cmd/upgrade/upgrade.go
+++ b/internal/cmd/upgrade/upgrade.go
@@ -156,16 +156,17 @@ func validateOptions(opts *Options) error {
 		return nil
 	}
 
-	stagePatch := corev1.Node{}
+	stagePatch := corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels:      map[string]string{},
+			Annotations: map[string]string{},
+		},
+	}
 
 	for _, l := range opts.StageLabels {
 		k, v, ok := strings.Cut(l, "=")
 		if !ok || k == "" {
 			return fmt.Errorf("invalid label %q: expected key=value", l)
-		}
-
-		if stagePatch.Labels == nil {
-			stagePatch.Labels = map[string]string{}
 		}
 
 		stagePatch.Labels[k] = v
@@ -177,17 +178,13 @@ func validateOptions(opts *Options) error {
 			return fmt.Errorf("invalid annotation %q: expected key=value", a)
 		}
 
-		if stagePatch.Annotations == nil {
-			stagePatch.Annotations = map[string]string{}
-		}
-
 		stagePatch.Annotations[k] = v
 	}
 
 	for _, tw := range opts.StageTaints {
 		kv, effect, ok := strings.Cut(tw, ":")
 		if !ok || effect == "" {
-			return fmt.Errorf("invalid taint %q: expected key=value:Effect", tw)
+			return fmt.Errorf("invalid taint %q: expected key[=value]:Effect", tw)
 		}
 
 		k, v, ok := strings.Cut(kv, "=")


### PR DESCRIPTION
on talos >= v1.13, offers the ability to upgrade the inactive/other partition without draining/rebooting the node whatsoever. the upgrade is therefore 'staged' and will be active with the next reboot. to simplify operations, the stage-label and stage-taint flags permit specifying arbitrary labels/taints, which can afterwards be used to selectively reboot nodes with a pending upgrade