### PR TITLE
fix(interactive): prevent looping forever when input cannot be read

### DIFF
--- a/internal/interactive/prompt.go
+++ b/internal/interactive/prompt.go
@@ -18,7 +18,7 @@ func ConfirmPrompt(prompt string) rune {
 	for {
 		fmt.Printf("%s [y/n]: ", prompt)
 
-		input, _ := reader.ReadString('\n')
+		input, err := reader.ReadString('\n')
 		input = strings.ToLower(strings.TrimSpace(input))
 
 		switch input {
@@ -27,6 +27,13 @@ func ConfirmPrompt(prompt string) rune {
 		case "n", "no":
 			return 'n'
 		default:
+			// no further read can succeed, so decline instead of reprompting forever
+			if err != nil {
+				fmt.Println()
+
+				return 'n'
+			}
+
 			fmt.Println("Please enter y or n")
 		}
 	}


### PR DESCRIPTION
`ConfirmPrompt` discards the error from `ReadString`, so when there's no readable input the empty string hits `default` and loops forever.

Non-interactive runs that reach a prompt will spin. In my case `topf nodes` with stdin closed hit `No secrets.yaml found for cluster X. Generate a new one?` and wrote 575MB in 8 seconds. `apply`, `reset`, `upgrade` share the confirm prompt.

Not applying `errors.Is(err, io.EOF)` since a closed fd or a detached tty will give `os.ErrClosed` and `EIO`, which loop just the same. It will end up having to cover all kinds of cases that can occur in different environments.

I have put the check after the switch so `printf 'y' | topf` still works, because `ReadString` returns the data and `io.EOF` together.